### PR TITLE
Release v0.1.2

### DIFF
--- a/.github/workflows/build_for_Binder.yml
+++ b/.github/workflows/build_for_Binder.yml
@@ -1,6 +1,7 @@
 name: Build Binder image for main branch
 on:
   workflow_dispatch:
+  workflow_call:
   push:
     branches:
       - main

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,6 +1,7 @@
 name: Build PyPI package and Binder image
 
 on:
+  workflow_dispatch:
   release:
     types: [ published ]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ Changelog
 
 Version 0.1.1
 =============
+Changed:
+- Now allowing wing geometry with no kink (#3)
+
+Fixed:
+- Fixed deprecation warnings (#4)
+- Now allowing versions greater than 0.1 for StdAtm
+
+Version 0.1.1
+=============
 - Fixed dependency to FAST-OAD
 
 Version 0.1.0

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 ![Tests](https://github.com/fast-aircraft-design/FAST-OAD_CS25/workflows/Tests/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/fast-oad-cs25/badge/?version=stable)](https://fast-oad.readthedocs.io/)
-
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/06d1fb8ee5c3429cb3cbb165413187bc)](https://www.codacy.com/gh/fast-aircraft-design/FAST-OAD_CS25/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fast-aircraft-design/FAST-OAD_CS25&amp;utm_campaign=Badge_Grade)
 [![codecov](https://codecov.io/gh/fast-aircraft-design/FAST-OAD_CS25/branch/main/graph/badge.svg?token=91CIX996RD)](https://codecov.io/gh/fast-aircraft-design/FAST-OAD_CS25)
-
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
+[![Documentation Status](https://readthedocs.org/projects/fast-oad-cs25/badge/?version=stable)](https://fast-oad.readthedocs.io/)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fast-aircraft-design/FAST-OAD_CS25.git/latest-release?urlpath=lab%2Ftree%2Fsrc%2Ffastoad_cs25%2Fnotebooks)
 
 

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,2 +1,1 @@
 fast-oad-cs25
-pandas==1.1.0


### PR DESCRIPTION
This release is especially needed to get rid of annoying deprecation warnings.

draft release: https://github.com/fast-aircraft-design/FAST-OAD_CS25/releases/tag/untagged-eecaa3c97e7a3be1cab8