### PR TITLE
Fixed unit of CL_alpha

### DIFF
--- a/src/fastoad_cs25/models/aerodynamics/components/compute_cl_alpha.py
+++ b/src/fastoad_cs25/models/aerodynamics/components/compute_cl_alpha.py
@@ -44,9 +44,9 @@ class ComputeCLAlpha(om.ExplicitComponent):
         self.add_input("data:geometry:wing:tip:thickness_ratio", val=np.nan)
 
         if self.options["low_speed_aero"]:
-            self.add_output("data:aerodynamics:aircraft:low_speed:CL_alpha")
+            self.add_output("data:aerodynamics:aircraft:low_speed:CL_alpha", units="1/rad")
         else:
-            self.add_output("data:aerodynamics:aircraft:cruise:CL_alpha")
+            self.add_output("data:aerodynamics:aircraft:cruise:CL_alpha", units="1/rad")
 
     def setup_partials(self):
         if self.options["low_speed_aero"]:

--- a/src/fastoad_cs25/models/geometry/compute_aero_center.py
+++ b/src/fastoad_cs25/models/geometry/compute_aero_center.py
@@ -2,7 +2,7 @@
     Estimation of aerodynamic center
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -41,8 +41,10 @@ class ComputeAeroCenter(om.ExplicitComponent):
         self.add_input(
             "data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25", val=np.nan, units="m"
         )
-        self.add_input("data:aerodynamics:aircraft:cruise:CL_alpha", val=np.nan)
-        self.add_input("data:aerodynamics:horizontal_tail:cruise:CL_alpha", val=np.nan)
+        self.add_input("data:aerodynamics:aircraft:cruise:CL_alpha", val=np.nan, units="1/rad")
+        self.add_input(
+            "data:aerodynamics:horizontal_tail:cruise:CL_alpha", val=np.nan, units="1/rad"
+        )
 
         self.add_output("data:aerodynamics:cruise:neutral_point:x")
 

--- a/src/fastoad_cs25/models/geometry/geom_components/ht/components/compute_ht_cl_alpha.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/ht/components/compute_ht_cl_alpha.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -30,7 +30,7 @@ class ComputeHTClalpha(om.ExplicitComponent):
         self.add_input("data:TLAR:cruise_mach", val=np.nan)
         self.add_input("data:geometry:horizontal_tail:sweep_25", val=np.nan, units="deg")
 
-        self.add_output("data:aerodynamics:horizontal_tail:cruise:CL_alpha")
+        self.add_output("data:aerodynamics:horizontal_tail:cruise:CL_alpha", units="1/rad")
 
     def setup_partials(self):
         self.declare_partials("data:aerodynamics:horizontal_tail:cruise:CL_alpha", "*", method="fd")

--- a/src/fastoad_cs25/models/geometry/geom_components/vt/components/compute_vt_clalpha.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/vt/components/compute_vt_clalpha.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail lift coefficient
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -33,7 +33,7 @@ class ComputeVTClalpha(om.ExplicitComponent):
         self.add_input("data:geometry:vertical_tail:aspect_ratio", val=np.nan)
         self.add_input("data:geometry:vertical_tail:sweep_25", val=np.nan, units="deg")
 
-        self.add_output("data:aerodynamics:vertical_tail:cruise:CL_alpha")
+        self.add_output("data:aerodynamics:vertical_tail:cruise:CL_alpha", units="1/rad")
 
     def setup_partials(self):
         self.declare_partials("data:aerodynamics:vertical_tail:cruise:CL_alpha", "*", method="fd")

--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_vt_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_vt_area.py
@@ -2,7 +2,7 @@
 Estimation of vertical tail area
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -30,7 +30,7 @@ class ComputeVTArea(om.ExplicitComponent):
         self.add_input("data:TLAR:cruise_mach", val=np.nan)
         self.add_input("data:weight:aircraft:CG:aft:MAC_position", val=np.nan)
         self.add_input("data:aerodynamics:fuselage:cruise:CnBeta", val=np.nan)
-        self.add_input("data:aerodynamics:vertical_tail:cruise:CL_alpha", val=np.nan)
+        self.add_input("data:aerodynamics:vertical_tail:cruise:CL_alpha", val=np.nan, units="1/rad")
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")
         self.add_input("data:geometry:wing:span", val=np.nan, units="m")

--- a/src/fastoad_cs25/models/weight/mass_breakdown/cs25.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/cs25.py
@@ -2,7 +2,7 @@
 Computation of load cases
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -40,7 +40,7 @@ class Loads(ExplicitComponent):
         self.add_input("data:weight:aircraft:MZFW", val=np.nan, units="kg")
         self.add_input("data:weight:aircraft:MFW", val=np.nan, units="kg")
         self.add_input("data:weight:aircraft:MTOW", val=np.nan, units="kg")
-        self.add_input("data:aerodynamics:aircraft:cruise:CL_alpha", val=np.nan)
+        self.add_input("data:aerodynamics:aircraft:cruise:CL_alpha", val=np.nan, units="1/rad")
         self.add_input("data:load_case:lc1:U_gust", val=np.nan, units="m/s")
         self.add_input("data:load_case:lc1:altitude", val=np.nan, units="ft")
         self.add_input("data:load_case:lc1:Vc_EAS", val=np.nan, units="m/s")


### PR DESCRIPTION
The inconsistent unit for CL_alpha variables (`"1/rad"` along with `None`) was the source of annoying warnings.

All CL_alpha variables have now `"1/rad"` as unit.