### PR TITLE
Small fixes

### DIFF
--- a/src/fastoad_cs25/models/aerodynamics/components/cd_compressibility.py
+++ b/src/fastoad_cs25/models/aerodynamics/components/cd_compressibility.py
@@ -48,7 +48,7 @@ class CdCompressibility(om.ExplicitComponent):
             val=0.0,
         )
         self.add_output(
-            "data:aerodynamics:aircraft:cruise:CD:compressibility",
+            "data:aerodynamics:aircraft:cruise:CD_compressibility",
             copy_shape="data:aerodynamics:aircraft:cruise:CL",
         )
 
@@ -80,4 +80,4 @@ class CdCompressibility(om.ExplicitComponent):
 
         cd_comp = np.minimum(max_cd_comp, 0.002 * np.exp(42.58 * (m - m_charac_comp)))
 
-        outputs["data:aerodynamics:aircraft:cruise:CD:compressibility"] = cd_comp
+        outputs["data:aerodynamics:aircraft:cruise:CD_compressibility"] = cd_comp

--- a/src/fastoad_cs25/models/aerodynamics/components/cd_trim.py
+++ b/src/fastoad_cs25/models/aerodynamics/components/cd_trim.py
@@ -32,13 +32,13 @@ class CdTrim(om.ExplicitComponent):
                 "data:aerodynamics:aircraft:low_speed:CL", shape_by_conn=True, val=np.nan
             )
             self.add_output(
-                "data:aerodynamics:aircraft:low_speed:CD:trim",
+                "data:aerodynamics:aircraft:low_speed:CD_trim",
                 copy_shape="data:aerodynamics:aircraft:low_speed:CL",
             )
         else:
             self.add_input("data:aerodynamics:aircraft:cruise:CL", shape_by_conn=True, val=np.nan)
             self.add_output(
-                "data:aerodynamics:aircraft:cruise:CD:trim",
+                "data:aerodynamics:aircraft:cruise:CD_trim",
                 copy_shape="data:aerodynamics:aircraft:cruise:CL",
             )
 
@@ -57,6 +57,6 @@ class CdTrim(om.ExplicitComponent):
             cd_trim.append(5.89 * pow(10, -4) * cl_val)
 
         if self.options["low_speed_aero"]:
-            outputs["data:aerodynamics:aircraft:low_speed:CD:trim"] = cd_trim
+            outputs["data:aerodynamics:aircraft:low_speed:CD_trim"] = cd_trim
         else:
-            outputs["data:aerodynamics:aircraft:cruise:CD:trim"] = cd_trim
+            outputs["data:aerodynamics:aircraft:cruise:CD_trim"] = cd_trim

--- a/src/fastoad_cs25/models/aerodynamics/components/compute_polar.py
+++ b/src/fastoad_cs25/models/aerodynamics/components/compute_polar.py
@@ -40,7 +40,7 @@ class ComputePolar(om.ExplicitComponent):
                 "data:aerodynamics:aircraft:low_speed:CD0", shape_by_conn=True, val=np.nan
             )
             self.add_input(
-                "data:aerodynamics:aircraft:low_speed:CD:trim", shape_by_conn=True, val=np.nan
+                "data:aerodynamics:aircraft:low_speed:CD_trim", shape_by_conn=True, val=np.nan
             )
             self.add_input(
                 "data:aerodynamics:aircraft:low_speed:induced_drag_coefficient", val=np.nan
@@ -85,10 +85,10 @@ class ComputePolar(om.ExplicitComponent):
             self.add_input("data:aerodynamics:aircraft:cruise:CL", shape_by_conn=True, val=np.nan)
             self.add_input("data:aerodynamics:aircraft:cruise:CD0", shape_by_conn=True, val=np.nan)
             self.add_input(
-                "data:aerodynamics:aircraft:cruise:CD:trim", shape_by_conn=True, val=np.nan
+                "data:aerodynamics:aircraft:cruise:CD_trim", shape_by_conn=True, val=np.nan
             )
             self.add_input(
-                "data:aerodynamics:aircraft:cruise:CD:compressibility",
+                "data:aerodynamics:aircraft:cruise:CD_compressibility",
                 shape_by_conn=True,
                 val=np.nan,
             )
@@ -116,7 +116,7 @@ class ComputePolar(om.ExplicitComponent):
         if self.options["polar_type"] != PolarType.HIGH_SPEED:
             cl = inputs["data:aerodynamics:aircraft:low_speed:CL"]
             cd0 = inputs["data:aerodynamics:aircraft:low_speed:CD0"]
-            cd_trim = inputs["data:aerodynamics:aircraft:low_speed:CD:trim"]
+            cd_trim = inputs["data:aerodynamics:aircraft:low_speed:CD_trim"]
             cd_c = 0.0
             coef_k = inputs["data:aerodynamics:aircraft:low_speed:induced_drag_coefficient"]
             if self.options["polar_type"] == PolarType.TAKEOFF:
@@ -134,8 +134,8 @@ class ComputePolar(om.ExplicitComponent):
         elif self.options["polar_type"] == PolarType.HIGH_SPEED:
             cl = inputs["data:aerodynamics:aircraft:cruise:CL"]
             cd0 = inputs["data:aerodynamics:aircraft:cruise:CD0"]
-            cd_trim = inputs["data:aerodynamics:aircraft:cruise:CD:trim"]
-            cd_c = inputs["data:aerodynamics:aircraft:cruise:CD:compressibility"]
+            cd_trim = inputs["data:aerodynamics:aircraft:cruise:CD_trim"]
+            cd_c = inputs["data:aerodynamics:aircraft:cruise:CD_compressibility"]
             coef_k = inputs["data:aerodynamics:aircraft:cruise:induced_drag_coefficient"]
             delta_cl_hl = 0.0
             delta_cd_hl = 0.0

--- a/src/fastoad_cs25/models/aerodynamics/components/tests/test_components.py
+++ b/src/fastoad_cs25/models/aerodynamics/components/tests/test_components.py
@@ -238,7 +238,7 @@ def test_cd_compressibility():
         )
 
         problem = run_system(CdCompressibility(), ivc)
-        return problem["data:aerodynamics:aircraft:cruise:CD:compressibility"][0]
+        return problem["data:aerodynamics:aircraft:cruise:CD_compressibility"][0]
 
     assert get_cd_compressibility(0.2, 0.9, 28, 0.12) == approx(0.0, abs=1e-5)
     assert get_cd_compressibility(0.78, 0.2, 28, 0.12) == approx(0.00028, abs=1e-5)
@@ -272,7 +272,7 @@ def test_cd_trim():
             "data:aerodynamics:aircraft:cruise:CL", 150 * [cl]
         )  # needed because size of input array is fixed
         problem = run_system(CdTrim(), ivc)
-        return problem["data:aerodynamics:aircraft:cruise:CD:trim"][0]
+        return problem["data:aerodynamics:aircraft:cruise:CD_trim"][0]
 
     assert get_cd_trim(0.5) == approx(0.0002945, abs=1e-6)
     assert get_cd_trim(0.9) == approx(0.0005301, abs=1e-6)

--- a/src/fastoad_cs25/models/weight/mass_breakdown/cs25.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/cs25.py
@@ -46,8 +46,10 @@ class Loads(ExplicitComponent):
         self.add_input("data:load_case:lc1:Vc_EAS", val=np.nan, units="m/s")
         self.add_input("data:load_case:lc2:U_gust", val=np.nan, units="m/s")
         self.add_input("data:load_case:lc2:altitude", val=np.nan, units="ft")
-        self.add_input("data:load_case:lc2:Vc_EAS", val=np.nan, units="kn")
+        self.add_input("data:load_case:lc2:Vc_EAS", val=np.nan, units="m/s")
 
+        self.add_output("data:mission:sizing:cs25:load_factor_1")
+        self.add_output("data:mission:sizing:cs25:load_factor_2")
         self.add_output("data:mission:sizing:cs25:sizing_load_1", units="kg")
         self.add_output("data:mission:sizing:cs25:sizing_load_2", units="kg")
 
@@ -104,6 +106,8 @@ class Loads(ExplicitComponent):
         mcv = min(0.8 * mfw, mtow - mzfw)
         n2m2 = n2 * (mtow - 0.55 * mcv)
 
+        outputs["data:mission:sizing:cs25:load_factor_1"] = n1
+        outputs["data:mission:sizing:cs25:load_factor_2"] = n2
         outputs["data:mission:sizing:cs25:sizing_load_1"] = n1m1
         outputs["data:mission:sizing:cs25:sizing_load_2"] = n2m2
 

--- a/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -100,8 +100,12 @@ def test_compute_loads():
 
     n1m1 = problem["data:mission:sizing:cs25:sizing_load_1"]
     n2m2 = problem["data:mission:sizing:cs25:sizing_load_2"]
+    n1 = problem['data:mission:sizing:cs25:load_factor_1']
+    n2 = problem['data:mission:sizing:cs25:load_factor_2']
     assert n1m1 == pytest.approx(240968, abs=10)
     assert n2m2 == pytest.approx(254130, abs=10)
+    assert n1 == pytest.approx(3.5, abs=0.01)
+    assert n2 == pytest.approx(3.5, abs=0.01)
 
 
 def test_compute_wing_weight():

--- a/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -100,8 +100,8 @@ def test_compute_loads():
 
     n1m1 = problem["data:mission:sizing:cs25:sizing_load_1"]
     n2m2 = problem["data:mission:sizing:cs25:sizing_load_2"]
-    n1 = problem['data:mission:sizing:cs25:load_factor_1']
-    n2 = problem['data:mission:sizing:cs25:load_factor_2']
+    n1 = problem["data:mission:sizing:cs25:load_factor_1"]
+    n2 = problem["data:mission:sizing:cs25:load_factor_2"]
     assert n1m1 == pytest.approx(240968, abs=10)
     assert n2m2 == pytest.approx(254130, abs=10)
     assert n1 == pytest.approx(3.75, abs=0.01)

--- a/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -104,8 +104,8 @@ def test_compute_loads():
     n2 = problem['data:mission:sizing:cs25:load_factor_2']
     assert n1m1 == pytest.approx(240968, abs=10)
     assert n2m2 == pytest.approx(254130, abs=10)
-    assert n1 == pytest.approx(3.5, abs=0.01)
-    assert n2 == pytest.approx(3.5, abs=0.01)
+    assert n1 == pytest.approx(3.75, abs=0.01)
+    assert n2 == pytest.approx(3.75, abs=0.01)
 
 
 def test_compute_wing_weight():


### PR DESCRIPTION
Hello,

this pull request for 3 reasons:

- Add load factors in the outputs of cs25.py, as they can be complementary inputs for further structural analysis in pre/post-treatment.
- Fix the unit bug for Vc_eas2.
- Propose to rename a few variables:
Currently two variables, CD:compressibility and CD:trim, are hidden in the outputs.xml because they are written after the vector of drag CD. This is due to the presence of the three following variables:
~CD
~CD:compressibility
~CD:trim
This PR proposes to use explicit naming instead:
~CD
~CD_trim
~CD_compressibility
which leaves all drag terms clearly visible by the user and at the same level as CD0.