### PR TITLE
Non-zero value for sweep angle of inner trailing edge

### DIFF
--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l2_l3.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l2_l3.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -26,7 +26,8 @@ class ComputeL2AndL3Wing(om.ExplicitComponent):
 
     def setup(self):
         self.add_input("data:geometry:wing:span", val=np.nan, units="m")
-        self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="deg")
+        self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="rad")
+        self.add_input("data:geometry:wing:sweep_100_inner", val=np.nan, units="rad")
         self.add_input("data:geometry:wing:root:virtual_chord", val=np.nan, units="m")
         self.add_input("data:geometry:wing:tip:chord", val=np.nan, units="m")
         self.add_input("data:geometry:wing:root:y", val=np.nan, units="m")
@@ -50,6 +51,7 @@ class ComputeL2AndL3Wing(om.ExplicitComponent):
                 "data:geometry:wing:span",
                 "data:geometry:fuselage:maximum_width",
                 "data:geometry:wing:sweep_25",
+                "data:geometry:wing:sweep_100_inner",
             ],
             method="fd",
         )
@@ -75,12 +77,14 @@ class ComputeL2AndL3Wing(om.ExplicitComponent):
         width_max = inputs["data:geometry:fuselage:maximum_width"]
         virtual_taper_ratio = inputs["data:geometry:wing:virtual_taper_ratio"]
         sweep_25 = inputs["data:geometry:wing:sweep_25"]
+        sweep_100 = inputs["data:geometry:wing:sweep_100_inner"]
 
         if y3_wing <= y2_wing:
             l2_wing = l3_wing = l1_wing
         else:
             l2_wing = l1_wing + (y3_wing - y2_wing) * (
-                math.tan(sweep_25 / 180.0 * math.pi)
+                math.tan(sweep_25)
+                - math.tan(sweep_100)
                 - 3.0 / 2.0 * (1.0 - virtual_taper_ratio) / (span - width_max) * l1_wing
             )
 

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -25,24 +25,23 @@ class ComputeSweepWing(om.ExplicitComponent):
     """Wing sweeps estimation"""
 
     def setup(self):
-        self.add_input("data:geometry:wing:kink:leading_edge:x:local", val=np.nan, units="m")
         self.add_input("data:geometry:wing:tip:leading_edge:x:local", val=np.nan, units="m")
         self.add_input("data:geometry:wing:root:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:tip:y", val=np.nan, units="m")
-        self.add_input("data:geometry:wing:root:chord", val=np.nan, units="m")
-        self.add_input("data:geometry:wing:kink:chord", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:root:virtual_chord", val=np.nan, units="m")
         self.add_input("data:geometry:wing:tip:chord", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:sweep_100_ratio", val=0.0, units=None)
 
         self.add_output("data:geometry:wing:sweep_0", units="deg")
-        self.add_output("data:geometry:wing:sweep_100_inner", units="deg")
+        self.add_output("data:geometry:wing:sweep_100_inner", val=0.0, units="deg")
         self.add_output("data:geometry:wing:sweep_100_outer", units="deg")
 
     def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:sweep_0",
             [
-                "data:geometry:wing:kink:leading_edge:x:local",
+                "data:geometry:wing:tip:leading_edge:x:local",
                 "data:geometry:wing:root:y",
                 "data:geometry:wing:kink:y",
             ],
@@ -51,50 +50,44 @@ class ComputeSweepWing(om.ExplicitComponent):
         self.declare_partials(
             "data:geometry:wing:sweep_100_inner",
             [
-                "data:geometry:wing:kink:leading_edge:x:local",
-                "data:geometry:wing:root:chord",
                 "data:geometry:wing:root:y",
-                "data:geometry:wing:kink:y",
-                "data:geometry:wing:kink:chord",
+                "data:geometry:wing:root:virtual_chord",
+                "data:geometry:wing:tip:leading_edge:x:local",
+                "data:geometry:wing:tip:y",
+                "data:geometry:wing:tip:chord",
             ],
             method="fd",
         )
         self.declare_partials(
             "data:geometry:wing:sweep_100_outer",
             [
-                "data:geometry:wing:kink:leading_edge:x:local",
+                "data:geometry:wing:root:y",
+                "data:geometry:wing:root:virtual_chord",
                 "data:geometry:wing:tip:leading_edge:x:local",
-                "data:geometry:wing:kink:y",
                 "data:geometry:wing:tip:y",
-                "data:geometry:wing:kink:chord",
                 "data:geometry:wing:tip:chord",
             ],
             method="fd",
         )
 
     def compute(self, inputs, outputs):
-        x3_wing = inputs["data:geometry:wing:kink:leading_edge:x:local"]
         x4_wing = inputs["data:geometry:wing:tip:leading_edge:x:local"]
         y2_wing = inputs["data:geometry:wing:root:y"]
         y3_wing = inputs["data:geometry:wing:kink:y"]
         y4_wing = inputs["data:geometry:wing:tip:y"]
-        l2_wing = inputs["data:geometry:wing:root:chord"]
-        l3_wing = inputs["data:geometry:wing:kink:chord"]
+        l1_wing = inputs["data:geometry:wing:root:virtual_chord"]
         l4_wing = inputs["data:geometry:wing:tip:chord"]
-
         outputs["data:geometry:wing:sweep_100_outer"] = (
-            math.atan((x4_wing + l4_wing - x3_wing - l3_wing) / (y4_wing - y3_wing))
-            / math.pi
-            * 180.0
+            math.atan((x4_wing + l4_wing - l1_wing) / (y4_wing - y2_wing)) / math.pi * 180.0
         )
         outputs["data:geometry:wing:sweep_0"] = (
             math.atan(x4_wing / (y4_wing - y2_wing)) / math.pi * 180.0
         )
         if y3_wing == y2_wing:
-            outputs["data:geometry:wing:sweep_100_inner"] = outputs[
-                "data:geometry:wing:sweep_100_outer"
-            ]
+            ratio = 1.0
         else:
-            outputs["data:geometry:wing:sweep_100_inner"] = (
-                math.atan((x3_wing + l3_wing - l2_wing) / (y3_wing - y2_wing)) / math.pi * 180
-            )
+            ratio = inputs["data:geometry:wing:sweep_100_ratio"]
+
+        outputs["data:geometry:wing:sweep_100_inner"] = (
+            outputs["data:geometry:wing:sweep_100_outer"] * ratio
+        )

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -2,7 +2,7 @@
 Test module for geometry functions of cg components
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -51,18 +51,34 @@ def test_geometry_wing_l1_l4():
     """Tests computation of the wing chords (l1 and l4)"""
 
     input_vars = om.IndepVarComp()
-    input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")
     input_vars.add_output("data:geometry:wing:area", 124.843, units="m**2")
-    input_vars.add_output("data:geometry:wing:span", 31.603, units="m")
     input_vars.add_output("data:geometry:wing:sweep_25", 25.0, units="deg")
     input_vars.add_output("data:geometry:wing:virtual_taper_ratio", 0.38, units=None)
     input_vars.add_output("data:geometry:wing:kink:y", 6.321, units="m")
     input_vars.add_output("data:geometry:wing:root:y", 1.96, units="m")
+    input_vars.add_output("data:geometry:wing:tip:y", 15.8015, units="m")
 
     problem = run_system(ComputeL1AndL4Wing(), input_vars)
 
     wing_l1 = problem["data:geometry:wing:root:virtual_chord"]
-    assert wing_l1 == pytest.approx(4.953, abs=1e-3)
+    assert wing_l1 == pytest.approx(4.952, abs=1e-3)
+    wing_l4 = problem["data:geometry:wing:tip:chord"]
+    assert wing_l4 == pytest.approx(1.882, abs=1e-3)
+
+    # With non-zero inner trailing edge sweep angle
+    input_vars = om.IndepVarComp()
+    input_vars.add_output("data:geometry:wing:area", 114.011, units="m**2")
+    input_vars.add_output("data:geometry:wing:sweep_25", 25.0, units="deg")
+    input_vars.add_output("data:geometry:wing:sweep_100_inner", 16.7, units="deg")
+    input_vars.add_output("data:geometry:wing:virtual_taper_ratio", 0.38, units=None)
+    input_vars.add_output("data:geometry:wing:kink:y", 6.321, units="m")
+    input_vars.add_output("data:geometry:wing:root:y", 1.96, units="m")
+    input_vars.add_output("data:geometry:wing:tip:y", 15.8015, units="m")
+
+    problem = run_system(ComputeL1AndL4Wing(), input_vars)
+
+    wing_l1 = problem["data:geometry:wing:root:virtual_chord"]
+    assert wing_l1 == pytest.approx(4.952, abs=1e-3)
     wing_l4 = problem["data:geometry:wing:tip:chord"]
     assert wing_l4 == pytest.approx(1.882, abs=1e-3)
 
@@ -74,6 +90,7 @@ def test_geometry_wing_l2_l3():
     input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")
     input_vars.add_output("data:geometry:wing:span", 31.603, units="m")
     input_vars.add_output("data:geometry:wing:sweep_25", 25.0, units="deg")
+    input_vars.add_output("data:geometry:wing:sweep_100_inner", 0.0, units="deg")
     input_vars.add_output("data:geometry:wing:virtual_taper_ratio", 0.38, units=None)
     input_vars.add_output("data:geometry:wing:kink:y", 6.321, units="m")
     input_vars.add_output("data:geometry:wing:root:virtual_chord", 4.953, units="m")
@@ -94,6 +111,7 @@ def test_geometry_wing_l2_l3():
     input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")
     input_vars.add_output("data:geometry:wing:span", 31.603, units="m")
     input_vars.add_output("data:geometry:wing:sweep_25", 25.0, units="deg")
+    input_vars.add_output("data:geometry:wing:sweep_100_inner", -150.0, units="deg")  # unused
     input_vars.add_output("data:geometry:wing:virtual_taper_ratio", 0.38, units=None)
     input_vars.add_output("data:geometry:wing:kink:y", 1.96, units="m")
     input_vars.add_output("data:geometry:wing:root:virtual_chord", 4.953, units="m")
@@ -151,7 +169,7 @@ def test_geometry_wing_sweep():
     """Tests computation of the wing sweeps"""
 
     input_vars = om.IndepVarComp()
-    input_vars.add_output("data:geometry:wing:kink:chord", 3.985, units="m")
+    input_vars.add_output("data:geometry:wing:root:virtual_chord", 4.953, units="m")
     input_vars.add_output("data:geometry:wing:kink:y", 6.321, units="m")
     input_vars.add_output("data:geometry:wing:kink:leading_edge:x:local", 2.275, units="m")
     input_vars.add_output("data:geometry:wing:root:chord", 6.26, units="m")

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -37,6 +37,12 @@ class ComputeWingGeometry(om.Group):
     """Wing geometry estimation"""
 
     def setup(self):
+        # These solvers are needed because sweep angle of inner trailing edge depends
+        # on sweep angle of outer trailing edge, that depends on (virtual) root chord,
+        # that depend on sweep angle of inner trailing edge.
+        self.nonlinear_solver = om.NonlinearBlockGS()
+        self.linear_solver = om.DirectSolver()
+
         self.add_subsystem("y_wing", ComputeYWing(), promotes=["*"])
         self.add_subsystem("l14_wing", ComputeL1AndL4Wing(), promotes=["*"])
         self.add_subsystem("l2l3_wing", ComputeL2AndL3Wing(), promotes=["*"])

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/tests/test_compute_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/tests/test_compute_wing.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -59,6 +59,7 @@ def test_compute_wing_with_kink():
 
 
 def test_compute_wing_without_kink():
+    # Method 1 : kink span_ratio = 0.
     input_vars = om.IndepVarComp()
     input_vars.add_output("data:TLAR:cruise_mach", 0.78, units=None)
     input_vars.add_output("data:geometry:fuselage:maximum_height", 4.06, units="m")
@@ -86,7 +87,45 @@ def test_compute_wing_without_kink():
     assert problem["data:geometry:wing:root:y"] == pytest.approx(1.96, abs=1e-2)
     assert problem["data:geometry:wing:span"] == pytest.approx(34.4, abs=1e-1)
     assert problem["data:geometry:wing:sweep_0"] == pytest.approx(27.35, abs=1e-2)
-    assert problem["data:geometry:wing:sweep_100_inner"] == pytest.approx(17.41, abs=1e-1)
+    assert problem["data:geometry:wing:sweep_100_outer"] == pytest.approx(17.41, abs=1e-1)
+    assert problem["data:geometry:wing:taper_ratio"] == pytest.approx(0.38, abs=1e-3)
+    assert problem["data:geometry:wing:thickness_ratio"] == pytest.approx(0.128, abs=1e-3)
+    assert problem["data:geometry:wing:tip:chord"] == pytest.approx(1.901, abs=1e-3)
+    assert problem["data:geometry:wing:tip:leading_edge:x:local"] == pytest.approx(7.883, abs=1e-3)
+    assert problem["data:geometry:wing:tip:thickness_ratio"] == pytest.approx(0.110, abs=1e-2)
+    assert problem["data:geometry:wing:tip:y"] == pytest.approx(17.2, abs=1e-1)
+    assert problem["data:geometry:wing:wetted_area"] == pytest.approx(210.461, abs=1e-3)
+    assert problem["data:weight:aircraft:MFW"] == pytest.approx(19322.5, abs=1e-1)
+
+    # Method 2 : sweep_100_ratio = 1.0
+    input_vars = om.IndepVarComp()
+    input_vars.add_output("data:TLAR:cruise_mach", 0.78, units=None)
+    input_vars.add_output("data:geometry:fuselage:maximum_height", 4.06, units="m")
+    input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")
+    input_vars.add_output("data:geometry:wing:area", 124.843, units="m**2")
+    input_vars.add_output("data:geometry:wing:aspect_ratio", 9.48, units=None)
+    input_vars.add_output("data:geometry:wing:kink:span_ratio", 0.4, units=None)
+    input_vars.add_output("data:geometry:wing:sweep_25", 25.0, units="deg")
+    input_vars.add_output("data:geometry:wing:sweep_100_ratio", 1.0, units=None)
+    input_vars.add_output("data:geometry:wing:virtual_taper_ratio", 0.38, units=None)
+
+    problem = run_system(ComputeWingGeometry(), input_vars)
+
+    assert problem["data:geometry:wing:MAC:leading_edge:x:local"] == pytest.approx(2.825, abs=1e-3)
+    assert problem["data:geometry:wing:MAC:length"] == pytest.approx(3.892, abs=1e-3)
+    assert problem["data:geometry:wing:MAC:y"] == pytest.approx(7.268, abs=1e-3)
+    assert problem["data:geometry:wing:b_50"] == pytest.approx(37.253, abs=1e-3)
+    assert problem["data:geometry:wing:kink:chord"] == pytest.approx(4.002, abs=1e-3)
+    assert problem["data:geometry:wing:kink:leading_edge:x:local"] == pytest.approx(2.545, abs=1e-3)
+    assert problem["data:geometry:wing:kink:thickness_ratio"] == pytest.approx(0.121, abs=1e-3)
+    assert problem["data:geometry:wing:kink:y"] == pytest.approx(6.88, abs=1e-2)
+    assert problem["data:geometry:wing:outer_area"] == pytest.approx(105.231, abs=1e-3)
+    assert problem["data:geometry:wing:root:chord"] == pytest.approx(5.003, abs=1e-2)
+    assert problem["data:geometry:wing:root:thickness_ratio"] == pytest.approx(0.159, abs=1e-3)
+    assert problem["data:geometry:wing:root:virtual_chord"] == pytest.approx(5.003, abs=1e-3)
+    assert problem["data:geometry:wing:root:y"] == pytest.approx(1.96, abs=1e-2)
+    assert problem["data:geometry:wing:span"] == pytest.approx(34.4, abs=1e-1)
+    assert problem["data:geometry:wing:sweep_0"] == pytest.approx(27.35, abs=1e-2)
     assert problem["data:geometry:wing:sweep_100_outer"] == pytest.approx(17.41, abs=1e-1)
     assert problem["data:geometry:wing:taper_ratio"] == pytest.approx(0.38, abs=1e-3)
     assert problem["data:geometry:wing:thickness_ratio"] == pytest.approx(0.128, abs=1e-3)

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -164,6 +164,7 @@ data:geometry:wing:spar_ratio:rear:tip || ratio (rear spar position)/(chord leng
 data:geometry:wing:sweep_0 || sweep angle at leading edge of wing
 data:geometry:wing:sweep_100_inner || sweep angle at trailing edge of wing (inner side of the kink)
 data:geometry:wing:sweep_100_outer || sweep angle at trailing edge of wing (outer side of the kink)
+data:geometry:wing:sweep_100_ratio || ratio inner/outer for sweep angles at trailing edge of wing
 data:geometry:wing:sweep_25 || sweep angle at 25% chord of wing
 data:geometry:wing:virtual_taper_ratio || taper ratio of wing computed from virtual root chord
 data:geometry:wing:taper_ratio || taper ratio of wing


### PR DESCRIPTION
Sweep angle of inner trailing edge is now controlled by a coefficient w.r.t. outer trailing edge sweep.

There is some drawback with this addition, because it requires a loop resolution. But it should remain very cheap.

Also, a bit of cleaning has been done, e.g. no need for a component to have as input both the span, and the y-position of the wing tip.