### PR TITLE
Update of wing-related geometry components

### DIFF
--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_b_50.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_b_50.py
@@ -1,9 +1,8 @@
 """
     Estimation of wing B50
 """
-
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,6 +13,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
 import numpy as np

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -1,7 +1,6 @@
 """
     Estimation of wing chords (l1 and l4)
 """
-
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -14,6 +13,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
 import numpy as np

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l2_l3.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l2_l3.py
@@ -1,7 +1,6 @@
 """
     Estimation of wing chords (l2 and l3)
 """
-
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -14,6 +13,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
 import numpy as np

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_mac_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_mac_wing.py
@@ -1,9 +1,8 @@
 """
     Estimation of wing mean aerodynamic chord
 """
-
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,6 +13,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import numpy as np
 import openmdao.api as om
 

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_mfw.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_mfw.py
@@ -2,7 +2,7 @@
     Estimation of max fuel weight
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -13,11 +13,16 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
 
+from ..constants import SERVICE_WING_GEOMETRY_MFW
+
 
 # TODO: This belongs more to mass breakdown than geometry
+@oad.RegisterSubmodel(SERVICE_WING_GEOMETRY_MFW, "fastoad.submodel.geometry.wing.mfw.legacy")
 class ComputeMFW(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Max fuel weight estimation"""

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_planform.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_planform.py
@@ -1,0 +1,49 @@
+"""
+Submodel for computing wing planform.
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import fastoad.api as oad
+import openmdao.api as om
+
+from .compute_b_50 import ComputeB50
+from .compute_l1_l4 import ComputeL1AndL4Wing
+from .compute_l2_l3 import ComputeL2AndL3Wing
+from .compute_mac_wing import ComputeMACWing
+from .compute_sweep_wing import ComputeSweepWing
+from .compute_x_wing import ComputeXWing
+from .compute_y_wing import ComputeYWing
+from ..constants import SERVICE_WING_GEOMETRY_PLANFORM
+
+
+@oad.RegisterSubmodel(
+    SERVICE_WING_GEOMETRY_PLANFORM, "fastoad.submodel.geometry.wing.planform.legacy"
+)
+class ComputeWingGeometry(om.Group):
+    """Computation of wing planform"""
+
+    def setup(self):
+        # These solvers are needed because sweep angle of inner trailing edge depends
+        # on sweep angle of outer trailing edge, that depends on (virtual) root chord,
+        # that depend on sweep angle of inner trailing edge.
+        self.nonlinear_solver = om.NonlinearBlockGS()
+        self.linear_solver = om.DirectSolver()
+
+        self.add_subsystem("y_wing", ComputeYWing(), promotes=["*"])
+        self.add_subsystem("l14_wing", ComputeL1AndL4Wing(), promotes=["*"])
+        self.add_subsystem("l2l3_wing", ComputeL2AndL3Wing(), promotes=["*"])
+        self.add_subsystem("x_wing", ComputeXWing(), promotes=["*"])
+        self.add_subsystem("mac_wing", ComputeMACWing(), promotes=["*"])
+        self.add_subsystem("b50_wing", ComputeB50(), promotes=["*"])
+        self.add_subsystem("sweep_wing", ComputeSweepWing(), promotes=["*"])

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
@@ -1,7 +1,6 @@
 """
     Estimation of wing sweeps
 """
-
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -14,6 +13,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
 import numpy as np

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_toc_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_toc_wing.py
@@ -1,9 +1,8 @@
 """
     Estimation of wing ToC
 """
-
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,13 +13,19 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
+import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
 
+from ..constants import SERVICE_WING_GEOMETRY_THICKNESS
 
-# TODO: computes relative thickness and generates profiles --> decompose
+
+@oad.RegisterSubmodel(
+    SERVICE_WING_GEOMETRY_THICKNESS, "fastoad.submodel.geometry.wing.thickness.legacy"
+)
 class ComputeToCWing(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Wing ToC estimation"""

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_wet_area_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_wet_area_wing.py
@@ -1,9 +1,8 @@
 """
     Estimation of wing wet area
 """
-
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,10 +13,17 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
 
+from ..constants import SERVICE_WING_GEOMETRY_WET_AREA
 
+
+@oad.RegisterSubmodel(
+    SERVICE_WING_GEOMETRY_WET_AREA, "fastoad.submodel.geometry.wing.wet_area.legacy"
+)
 class ComputeWetAreaWing(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Wing wet area estimation"""

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_x_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_x_wing.py
@@ -1,9 +1,8 @@
 """
     Estimation of wing Xs
 """
-
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,6 +13,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
 import numpy as np

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_y_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_y_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,6 +14,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import math
 
 import numpy as np

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
@@ -18,10 +18,10 @@ import fastoad.api as oad
 import openmdao.api as om
 
 from .constants import (
+    SERVICE_WING_GEOMETRY_MFW,
     SERVICE_WING_GEOMETRY_PLANFORM,
     SERVICE_WING_GEOMETRY_THICKNESS,
     SERVICE_WING_GEOMETRY_WET_AREA,
-    SERVICE_WING_GEOMETRY_MFW,
 )
 from ...constants import SERVICE_WING_GEOMETRY
 
@@ -30,17 +30,21 @@ from ...constants import SERVICE_WING_GEOMETRY
 class ComputeWingGeometry(om.Group):
     """Wing geometry estimation"""
 
+    def initialize(self):
+        self.options.declare("compute_thicknesses", types=bool, default=True)
+
     def setup(self):
         self.add_subsystem(
             "y_wing",
             oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_PLANFORM),
             promotes=["*"],
         )
-        self.add_subsystem(
-            "toc_wing",
-            oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_THICKNESS),
-            promotes=["*"],
-        )
+        if self.options["compute_thicknesses"]:
+            self.add_subsystem(
+                "toc_wing",
+                oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_THICKNESS),
+                promotes=["*"],
+            )
         self.add_subsystem(
             "wetarea_wing",
             oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_WET_AREA),

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
@@ -1,7 +1,6 @@
 """
-    Estimation of wing geometry
+Estimation of wing geometry
 """
-
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -18,38 +17,35 @@
 import fastoad.api as oad
 import openmdao.api as om
 
-from .components.compute_b_50 import ComputeB50
-from .components.compute_l1_l4 import ComputeL1AndL4Wing
-from .components.compute_l2_l3 import ComputeL2AndL3Wing
-from .components.compute_mac_wing import ComputeMACWing
-from .components.compute_mfw import ComputeMFW
-from .components.compute_sweep_wing import ComputeSweepWing
-from .components.compute_toc_wing import ComputeToCWing
-from .components.compute_wet_area_wing import ComputeWetAreaWing
-from .components.compute_x_wing import ComputeXWing
-from .components.compute_y_wing import ComputeYWing
+from .constants import (
+    SERVICE_WING_GEOMETRY_PLANFORM,
+    SERVICE_WING_GEOMETRY_THICKNESS,
+    SERVICE_WING_GEOMETRY_WET_AREA,
+    SERVICE_WING_GEOMETRY_MFW,
+)
 from ...constants import SERVICE_WING_GEOMETRY
 
 
 @oad.RegisterSubmodel(SERVICE_WING_GEOMETRY, "fastoad.submodel.geometry.wing.legacy")
 class ComputeWingGeometry(om.Group):
-    # TODO: Document equations. Cite sources
     """Wing geometry estimation"""
 
     def setup(self):
-        # These solvers are needed because sweep angle of inner trailing edge depends
-        # on sweep angle of outer trailing edge, that depends on (virtual) root chord,
-        # that depend on sweep angle of inner trailing edge.
-        self.nonlinear_solver = om.NonlinearBlockGS()
-        self.linear_solver = om.DirectSolver()
-
-        self.add_subsystem("y_wing", ComputeYWing(), promotes=["*"])
-        self.add_subsystem("l14_wing", ComputeL1AndL4Wing(), promotes=["*"])
-        self.add_subsystem("l2l3_wing", ComputeL2AndL3Wing(), promotes=["*"])
-        self.add_subsystem("x_wing", ComputeXWing(), promotes=["*"])
-        self.add_subsystem("mac_wing", ComputeMACWing(), promotes=["*"])
-        self.add_subsystem("b50_wing", ComputeB50(), promotes=["*"])
-        self.add_subsystem("sweep_wing", ComputeSweepWing(), promotes=["*"])
-        self.add_subsystem("toc_wing", ComputeToCWing(), promotes=["*"])
-        self.add_subsystem("wetarea_wing", ComputeWetAreaWing(), promotes=["*"])
-        self.add_subsystem("mfw", ComputeMFW(), promotes=["*"])
+        self.add_subsystem(
+            "y_wing",
+            oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_PLANFORM),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "toc_wing",
+            oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_THICKNESS),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "wetarea_wing",
+            oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_WET_AREA),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "mfw", oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_MFW), promotes=["*"]
+        )

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/constants.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/constants.py
@@ -1,0 +1,18 @@
+"""Constants for identifiers of wing geometry submodel requirements."""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+SERVICE_WING_GEOMETRY_PLANFORM = "service.geometry.wing.y_positions"
+SERVICE_WING_GEOMETRY_THICKNESS = "service.geometry.wing.thickness"
+SERVICE_WING_GEOMETRY_WET_AREA = "service.geometry.wing.wet_area"
+SERVICE_WING_GEOMETRY_MFW = "service.geometry.wing.mfw"

--- a/src/fastoad_cs25/models/loops/wing_area_component/tests/__init__.py
+++ b/src/fastoad_cs25/models/loops/wing_area_component/tests/__init__.py
@@ -1,0 +1,12 @@
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/fastoad_cs25/models/loops/wing_area_component/tests/test_update_wing_area_aero.py
+++ b/src/fastoad_cs25/models/loops/wing_area_component/tests/test_update_wing_area_aero.py
@@ -1,0 +1,52 @@
+"""
+test module for wing area computation
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+from fastoad._utils.testing import run_system
+from numpy.testing import assert_allclose
+from openmdao.utils.assert_utils import assert_check_partials
+
+from ..update_wing_area_aero import UpdateWingAreaAero, WingAreaConstraintsAero
+
+
+def test_update_wing_area_aero():
+    ivc = om.IndepVarComp()
+    ivc.add_output("data:TLAR:approach_speed", val=132, units="kn")
+    ivc.add_output("data:weight:aircraft:MLW", val=66300, units="kg")
+    ivc.add_output("data:aerodynamics:aircraft:landing:CL_max", val=2.8)
+    ivc.add_output("data:geometry:wing:area", val=2.80)
+
+    problem = run_system(UpdateWingAreaAero(), ivc)
+    assert_allclose(problem["wing_area:aero"], 124.38, atol=1e-2)
+
+    data = problem.check_partials(out_stream=None)
+    assert_check_partials(data, atol=1, rtol=1e-4)
+
+
+def test_wing_area_constraints_aero():
+    ivc = om.IndepVarComp()
+    ivc.add_output("data:TLAR:approach_speed", val=132, units="kn")
+    ivc.add_output("data:weight:aircraft:MLW", val=66300, units="kg")
+    ivc.add_output("data:aerodynamics:aircraft:landing:CL_max", val=2.8)
+    ivc.add_output("data:geometry:wing:area", val=116.09, units="m**2")
+
+    problem = run_system(WingAreaConstraintsAero(), ivc)
+    assert_allclose(
+        problem["data:aerodynamics:aircraft:landing:additional_CL_capacity"], -0.2, atol=1e-2
+    )
+
+    data = problem.check_partials(out_stream=None)
+    assert_check_partials(data, atol=1, rtol=1e-4)

--- a/src/fastoad_cs25/models/loops/wing_area_component/tests/test_update_wing_area_geom.py
+++ b/src/fastoad_cs25/models/loops/wing_area_component/tests/test_update_wing_area_geom.py
@@ -1,0 +1,48 @@
+"""
+test module for wing area computation
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+from fastoad._utils.testing import run_system
+from numpy.testing import assert_allclose
+from openmdao.utils.assert_utils import assert_check_partials
+
+from ..update_wing_area_geom import UpdateWingAreaGeom, WingAreaConstraintsGeom
+
+
+def test_update_wing_area_geom():
+    ivc = om.IndepVarComp()
+    ivc.add_output("data:geometry:wing:aspect_ratio", 9.48)
+    ivc.add_output("data:geometry:wing:root:thickness_ratio", 0.15)
+    ivc.add_output("data:geometry:wing:tip:thickness_ratio", 0.11)
+    ivc.add_output("data:weight:aircraft:sizing_block_fuel", val=20500, units="kg")
+
+    problem = run_system(UpdateWingAreaGeom(), ivc)
+    assert_allclose(problem["wing_area:geom"], 133.97, atol=1e-2)
+
+    data = problem.check_partials(out_stream=None)
+    assert_check_partials(data, atol=1, rtol=1e-4)
+
+
+def test_wing_area_constraints_geom():
+    ivc = om.IndepVarComp()
+    ivc.add_output("data:weight:aircraft:sizing_block_fuel", val=15000.0, units="kg")
+    ivc.add_output("data:weight:aircraft:MFW", val=12000.0, units="kg")
+
+    problem = run_system(WingAreaConstraintsGeom(), ivc)
+    assert_allclose(problem["data:weight:aircraft:additional_fuel_capacity"], -3000.0, atol=1e-2)
+
+    data = problem.check_partials(out_stream=None)
+    assert_check_partials(data, atol=1, rtol=1e-4)


### PR DESCRIPTION
This PR proposes some small enhancements:

- computation of wing area can now be customized through 2 options to (de)activate the criteria of fuel capacity and/or approach speed
- computation of wing geometry now uses submodels and has now an option for (de)activating the computation of wing thickness