### PR TITLE
Correction tail geometry

### DIFF
--- a/src/fastoad_cs25/models/geometry/geom_components/ht/components/compute_ht_mac.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/ht/components/compute_ht_mac.py
@@ -70,17 +70,17 @@ class ComputeHTMAC(om.ExplicitComponent):
         sweep_25_ht = inputs["data:geometry:horizontal_tail:sweep_25"]
         b_h = inputs["data:geometry:horizontal_tail:span"]
 
-        tmp = (
-            root_chord * 0.25 + b_h / 2 * math.tan(sweep_25_ht / 180.0 * math.pi) - tip_chord * 0.25
-        )
-
         mac_ht = (
             (root_chord**2 + root_chord * tip_chord + tip_chord**2)
             / (tip_chord + root_chord)
             * 2
             / 3
         )
-        x0_ht = (tmp * (root_chord + 2 * tip_chord)) / (3 * (root_chord + tip_chord))
+
+        x0_ht = (root_chord / 4) + (b_h / 6) * math.tan(sweep_25_ht / 180.0 * math.pi) * (
+            (root_chord + 2 * tip_chord) / (root_chord + tip_chord)
+        )
+
         y0_ht = (b_h * (0.5 * root_chord + tip_chord)) / (3 * (root_chord + tip_chord))
 
         outputs["data:geometry:horizontal_tail:MAC:length"] = mac_ht

--- a/src/fastoad_cs25/models/geometry/geom_components/ht/components/compute_ht_mac.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/ht/components/compute_ht_mac.py
@@ -28,7 +28,7 @@ class ComputeHTMAC(om.ExplicitComponent):
     def setup(self):
         self.add_input("data:geometry:horizontal_tail:center:chord", val=np.nan, units="m")
         self.add_input("data:geometry:horizontal_tail:tip:chord", val=np.nan, units="m")
-        self.add_input("data:geometry:horizontal_tail:sweep_25", val=np.nan, units="deg")
+        self.add_input("data:geometry:horizontal_tail:sweep_25", val=np.nan, units="rad")
         self.add_input("data:geometry:horizontal_tail:span", val=np.nan, units="m")
 
         self.add_output("data:geometry:horizontal_tail:MAC:length", units="m")
@@ -77,7 +77,7 @@ class ComputeHTMAC(om.ExplicitComponent):
             / 3
         )
 
-        x0_ht = (root_chord / 4) + (b_h / 6) * math.tan(sweep_25_ht / 180.0 * math.pi) * (
+        x0_ht = (root_chord / 4) + (b_h / 6) * math.tan(sweep_25_ht) * (
             (root_chord + 2 * tip_chord) / (root_chord + tip_chord)
         )
 

--- a/src/fastoad_cs25/models/geometry/geom_components/vt/components/compute_vt_mac.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/vt/components/compute_vt_mac.py
@@ -60,15 +60,17 @@ class ComputeVTMAC(om.ExplicitComponent):
         sweep_25_vt = inputs["data:geometry:vertical_tail:sweep_25"]
         b_v = inputs["data:geometry:vertical_tail:span"]
 
-        tmp = root_chord * 0.25 + b_v * math.tan(sweep_25_vt / 180.0 * math.pi) - tip_chord * 0.25
-
         mac_vt = (
             (root_chord**2 + root_chord * tip_chord + tip_chord**2)
             / (tip_chord + root_chord)
             * 2.0
             / 3.0
         )
-        x0_vt = (tmp * (root_chord + 2 * tip_chord)) / (3 * (root_chord + tip_chord))
+
+        x0_vt = (root_chord / 4) + (b_v / 3) * math.tan(sweep_25_vt / 180.0 * math.pi) * (
+            (root_chord + 2 * tip_chord) / (root_chord + tip_chord)
+        )
+
         z0_vt = (2 * b_v * (0.5 * root_chord + tip_chord)) / (3 * (root_chord + tip_chord))
 
         outputs["data:geometry:vertical_tail:MAC:length"] = mac_vt

--- a/src/fastoad_cs25/models/geometry/geom_components/vt/components/compute_vt_mac.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/vt/components/compute_vt_mac.py
@@ -28,7 +28,7 @@ class ComputeVTMAC(om.ExplicitComponent):
     def setup(self):
         self.add_input("data:geometry:vertical_tail:root:chord", val=np.nan, units="m")
         self.add_input("data:geometry:vertical_tail:tip:chord", val=np.nan, units="m")
-        self.add_input("data:geometry:vertical_tail:sweep_25", val=np.nan, units="deg")
+        self.add_input("data:geometry:vertical_tail:sweep_25", val=np.nan, units="rad")
         self.add_input("data:geometry:vertical_tail:span", val=np.nan, units="m")
 
         self.add_output("data:geometry:vertical_tail:MAC:length", units="m")
@@ -67,7 +67,7 @@ class ComputeVTMAC(om.ExplicitComponent):
             / 3.0
         )
 
-        x0_vt = (root_chord / 4) + (b_v / 3) * math.tan(sweep_25_vt / 180.0 * math.pi) * (
+        x0_vt = (root_chord / 4) + (b_v / 3) * math.tan(sweep_25_vt) * (
             (root_chord + 2 * tip_chord) / (root_chord + tip_chord)
         )
 

--- a/src/fastoad_cs25/models/geometry/tests/test_geometry_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/tests/test_geometry_geom_comps.py
@@ -291,7 +291,7 @@ def test_compute_vt_mac(input_xml):
     length = problem["data:geometry:vertical_tail:MAC:length"]
     assert length == pytest.approx(4.161, abs=1e-3)
     vt_x0 = problem["data:geometry:vertical_tail:MAC:at25percent:x:local"]
-    assert vt_x0 == pytest.approx(2.321, abs=1e-3)
+    assert vt_x0 == pytest.approx(3.361, abs=1e-3)
     vt_z0 = problem["data:geometry:vertical_tail:MAC:z"]
     assert vt_z0 == pytest.approx(2.716, abs=1e-3)
 

--- a/src/fastoad_cs25/models/geometry/tests/test_geometry_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/tests/test_geometry_geom_comps.py
@@ -146,7 +146,7 @@ def test_compute_ht_mac(input_xml):
     length = problem["data:geometry:horizontal_tail:MAC:length"]
     assert length == pytest.approx(3.141, abs=1e-3)
     ht_x0 = problem["data:geometry:horizontal_tail:MAC:at25percent:x:local"]
-    assert ht_x0 == pytest.approx(1.656, abs=1e-3)
+    assert ht_x0 == pytest.approx(2.441, abs=1e-3)
     ht_y0 = problem["data:geometry:horizontal_tail:MAC:y"]
     assert ht_y0 == pytest.approx(2.519, abs=1e-3)
 

--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
@@ -2,7 +2,7 @@
 Estimation of horizontal tail area
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -92,9 +92,7 @@ class ComputeHTArea(om.ExplicitComponent):
 
         vtp_tip_chord = inputs["data:geometry:vertical_tail:tip:chord"]
         vt_le_x = inputs["data:geometry:vertical_tail:tip:leading_edge:x"]
-        htp_leading_edge_position = inputs[
-            "settings:geometry:horizontal_tail:position_ratio_on_VTP"
-        ]
+        htp_le_position_ratio = inputs["settings:geometry:horizontal_tail:position_ratio_on_VTP"]
         htp_x0 = inputs["data:geometry:horizontal_tail:MAC:at25percent:x:local"]
 
         delta_lg = x_main_lg - x_front_lg
@@ -125,7 +123,7 @@ class ComputeHTArea(om.ExplicitComponent):
         ht_volume_coeff = cm_front_lg
         if tail_type == 1:
             aero_centers_distance = (
-                vt_le_x + htp_leading_edge_position * vtp_tip_chord + htp_x0 - x_wing_aero_center
+                vt_le_x + htp_le_position_ratio * vtp_tip_chord + htp_x0 - x_wing_aero_center
             )
             wet_area_coeff = 2.0  # TODO: explore more thoroughly this coefficient
         elif tail_type == 0:

--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
@@ -124,7 +124,9 @@ class ComputeHTArea(om.ExplicitComponent):
 
         ht_volume_coeff = cm_front_lg
         if tail_type == 1:
-            aero_centers_distance = vt_le_x + htp_leading_edge_position * vtp_tip_chord + htp_x0
+            aero_centers_distance = (
+                vt_le_x + htp_leading_edge_position * vtp_tip_chord + htp_x0 - x_wing_aero_center
+            )
             wet_area_coeff = 2.0  # TODO: explore more thoroughly this coefficient
         elif tail_type == 0:
             aero_centers_distance = htp_aero_center_ratio * fuselage_length - x_wing_aero_center

--- a/src/fastoad_cs25/models/handling_qualities/tests/test_tail_areas.py
+++ b/src/fastoad_cs25/models/handling_qualities/tests/test_tail_areas.py
@@ -56,7 +56,8 @@ def test_compute_ht_area(input_xml):
     # Testing conventional tail
     input_vars = input_xml.read(only=input_list).to_ivc()
 
-    input_vars.add_output("data:geometry:vertical_tail:tip:leading_edge:x", 19.89)
+    # Input needed, but value not used for conventional tail
+    input_vars.add_output("data:geometry:vertical_tail:tip:leading_edge:x", 0.0)
 
     problem = run_system(ComputeHTArea(), input_vars)
 
@@ -71,15 +72,15 @@ def test_compute_ht_area(input_xml):
     input_list.remove("data:geometry:has_T_tail")
     input_vars = input_xml.read(only=input_list).to_ivc()
     input_vars.add_output("data:geometry:has_T_tail", 1.0)
-    input_vars.add_output("data:geometry:vertical_tail:tip:leading_edge:x", 19.89)
+    input_vars.add_output("data:geometry:vertical_tail:tip:leading_edge:x", 32.21272)
     problem_ttail = run_system(ComputeHTArea(), input_vars)
 
     ht_lp = problem_ttail["data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25"]
-    assert ht_lp == pytest.approx(5.35, abs=1e-2)
+    assert ht_lp == pytest.approx(17.68, abs=1e-2)
     wet_area = problem_ttail["data:geometry:horizontal_tail:wetted_area"]
-    assert wet_area == pytest.approx(232.20, abs=1e-2)
+    assert wet_area == pytest.approx(70.31, abs=1e-2)
     ht_area = problem_ttail["data:geometry:horizontal_tail:area"]
-    assert ht_area == pytest.approx(116.10, abs=1e-2)
+    assert ht_area == pytest.approx(35.15, abs=1e-2)
 
 
 def test_compute_vt_area(input_xml):

--- a/src/fastoad_cs25/models/handling_qualities/tests/test_tail_areas.py
+++ b/src/fastoad_cs25/models/handling_qualities/tests/test_tail_areas.py
@@ -75,11 +75,11 @@ def test_compute_ht_area(input_xml):
     problem_ttail = run_system(ComputeHTArea(), input_vars)
 
     ht_lp = problem_ttail["data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25"]
-    assert ht_lp == pytest.approx(21.8, abs=1e-2)
+    assert ht_lp == pytest.approx(5.35, abs=1e-2)
     wet_area = problem_ttail["data:geometry:horizontal_tail:wetted_area"]
-    assert wet_area == pytest.approx(56.98, abs=1e-2)
+    assert wet_area == pytest.approx(232.20, abs=1e-2)
     ht_area = problem_ttail["data:geometry:horizontal_tail:area"]
-    assert ht_area == pytest.approx(28.5, abs=1e-2)
+    assert ht_area == pytest.approx(116.10, abs=1e-2)
 
 
 def test_compute_vt_area(input_xml):

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
@@ -1,6 +1,6 @@
 <!--
   ~ This file is part of FAST-OAD_CS25
-  ~ Copyright (C) 2022 ONERA & ISAE-SUPAERO
+  ~ Copyright (C) 2024 ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
@@ -16,548 +16,570 @@
 <FASTOAD_model>
   <data>
     <TLAR>
-      <NPAX>150.0<!--top-level requirement: number of passengers, assuming a classic eco/business class repartition--></NPAX>
-      <approach_speed units="kn">132.0<!--top-level requirement: approach speed--></approach_speed>
-      <cruise_mach>0.78<!--top-level requirement: cruise Mach number--></cruise_mach>
-      <max_TOFL units="m">0.0<!--top-level requirement: maximum takeoff field length--></max_TOFL>
-      <range units="NM">2750.0<!--top-level requirement: design range--></range>
+      <NPAX is_input="True">150.0<!--top-level requirement: number of passengers, assuming a classic eco/business class repartition--></NPAX>
+      <approach_speed units="knot" is_input="True">132.0<!--top-level requirement: approach speed--></approach_speed>
+      <cruise_mach is_input="True">0.78<!--Input defined by the mission.--></cruise_mach>
+      <range units="nmi" is_input="True">2750.0<!--Input defined by the mission.--></range>
     </TLAR>
     <geometry>
-      <has_T_tail>0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <has_T_tail is_input="True">0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
       <aircraft>
-        <wetted_area units="m**2">801.596901742<!--total wetted area--></wetted_area>
+        <wetted_area units="m**2" is_input="False">801.4521728701311<!--total wetted area--></wetted_area>
       </aircraft>
       <cabin>
-        <NPAX1>157.0<!--number of passengers if there are only economical class seats--></NPAX1>
-        <aisle_width units="m">0.48<!--width of aisles--></aisle_width>
-        <exit_width units="m">0.51<!--width of exits--></exit_width>
-        <length units="m">30.38096484<!--cabin length--></length>
-        <pallet_count>10.0<!--number of pallet in cargo hold--></pallet_count>
+        <NPAX1 is_input="False">157.0<!--number of passengers if there are only economical class seats--></NPAX1>
+        <aisle_width units="m" is_input="True">0.48<!--width of aisles--></aisle_width>
+        <exit_width units="m" is_input="True">0.51<!--width of exits--></exit_width>
+        <length units="m" is_input="False">30.380964840000004<!--cabin length--></length>
         <containers>
-          <count>5.0<!--total number of cargo containers--></count>
-          <count_by_row>1.0<!--number of cargo containers along width--></count_by_row>
+          <count_by_row is_input="True">1.0<!--number of cargo containers along width--></count_by_row>
         </containers>
         <crew_count>
-          <commercial>4.0<!--number of commercial crew members--></commercial>
-          <technical>2.0<!--number of technical crew members--></technical>
+          <commercial is_input="False">4.0<!--number of commercial crew members--></commercial>
+          <technical is_input="True">2.0<!--number of technical crew members--></technical>
         </crew_count>
         <seats>
           <economical>
-            <count_by_row>6.0<!--number of economical class seats along width--></count_by_row>
-            <length units="m">0.86<!--length of economical class seats--></length>
-            <width units="m">0.46<!--width of economical class seats--></width>
+            <count_by_row is_input="True">6.0<!--number of economical class seats along width--></count_by_row>
+            <length units="m" is_input="True">0.86<!--length of economical class seats--></length>
+            <width units="m" is_input="True">0.46<!--width of economical class seats--></width>
           </economical>
         </seats>
       </cabin>
       <flap>
-        <chord_ratio>0.197<!--mean value of (flap chord)/(section chord)--></chord_ratio>
-        <span_ratio>0.8<!--ratio (width of flaps)/(total span)--></span_ratio>
+        <chord_ratio is_input="True">0.197<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+        <span_ratio is_input="True">0.8<!--ratio (width of flaps)/(total span)--></span_ratio>
       </flap>
       <fuselage>
-        <PAX_length units="m">22.87<!--length of passenger-dedicated zone--></PAX_length>
-        <front_length units="m">6.901796<!--length of front non-cylindrical part of the fuselage--></front_length>
-        <length units="m">37.507364<!--total fuselage length--></length>
-        <maximum_height units="m">4.05988<!--maximum fuselage height--></maximum_height>
-        <maximum_width units="m">3.91988<!--maximum fuselage width--></maximum_width>
-        <rear_length units="m">14.615568<!--length of rear non-cylindrical part of the fuselage--></rear_length>
-        <wetted_area units="m**2">401.956000943<!--wetted area of fuselage--></wetted_area>
+        <PAX_length units="m" is_input="False">22.87<!--length of passenger-dedicated zone--></PAX_length>
+        <front_length units="m" is_input="False">6.901795999999999<!--length of front non-cylindrical part of the fuselage--></front_length>
+        <length units="m" is_input="False">37.507364<!--total fuselage length--></length>
+        <maximum_height units="m" is_input="False">4.05988<!--maximum fuselage height--></maximum_height>
+        <maximum_width units="m" is_input="False">3.91988<!--maximum fuselage width--></maximum_width>
+        <rear_length units="m" is_input="False">14.615568<!--length of rear non-cylindrical part of the fuselage--></rear_length>
+        <wetted_area units="m**2" is_input="False">401.95600094323777<!--wetted area of fuselage--></wetted_area>
       </fuselage>
       <horizontal_tail>
-        <area units="m**2">35.6002171464<!--horizontal tail area--></area>
-        <aspect_ratio>4.28778048454<!--aspect ratio of horizontal tail--></aspect_ratio>
-        <span units="m">12.354995602<!--horizontal tail span--></span>
-        <sweep_0 units="deg">33.3165149655<!--sweep angle at leading edge of horizontal tail--></sweep_0>
-        <sweep_100 units="deg">8.80894178428<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
-        <sweep_25 units="deg">28.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
-        <taper_ratio>0.3<!--taper ratio of horizontal tail--></taper_ratio>
-        <thickness_ratio>0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
-        <volume_coefficient>1.12214252639<!--volume coefficient of horizontal tail--></volume_coefficient>
-        <wetted_area units="m**2">71.2004342928<!--wetted area of horizontal tail--></wetted_area>
+        <area units="m**2" is_input="False">35.50596767649052<!--horizontal tail area--></area>
+        <aspect_ratio is_input="True">4.28778048454<!--aspect ratio of horizontal tail--></aspect_ratio>
+        <span units="m" is_input="False">12.338630199159361<!--horizontal tail span--></span>
+        <sweep_0 units="deg" is_input="False">33.31651496553977<!--sweep angle at leading edge of horizontal tail--></sweep_0>
+        <sweep_100 units="deg" is_input="False">8.80894178425667<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
+        <sweep_25 units="deg" is_input="True">28.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <taper_ratio is_input="True">0.3<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <wetted_area units="m**2" is_input="False">71.01193535298104<!--wetted area of horizontal tail--></wetted_area>
         <MAC>
-          <length units="m">3.15992579473<!--mean aerodynamic chord length of horizontal tail--></length>
-          <y units="m">2.53435807221<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
+          <length units="m" is_input="False">3.1557401632488755<!--_inp_data:geometry:horizontal_tail:MAC:length--></length>
+          <y units="m" is_input="False">2.531001066494228<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
           <at25percent>
-            <x>
-              <from_wingMAC25 units="m">17.52490524<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
-            </x>
+            <x units="m" is_input="False">34.131701240000005<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x--><from_wingMAC25 units="m" is_input="False">17.524905240000006<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">2.452536512401557<!--X-position of the 25% of mean aerodynamic chord of horizontal tail w.r.t. leading edge of root chord--></local></x>
           </at25percent>
+          <leading_edge>
+            <x units="m" is_input="False">33.342766199187786<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x--><local units="m" is_input="False">1.6636014715893381<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x:local--></local></x>
+          </leading_edge>
         </MAC>
         <center>
-          <chord units="m">4.43298942427<!--chord length at center of horizontal tail--></chord>
+          <chord units="m" is_input="False">4.427117495205257<!--chord length at center of horizontal tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">31.679164727598447<!--_inp_data:geometry:horizontal_tail:center:leading_edge:x--><local units="m" is_input="False">2.220446049250313e-16<!--X-position of the leading edge at center of horizontal tail w.r.t. leading edge of center chord--></local></x>
+          </leading_edge>
         </center>
         <tip>
-          <chord units="m">1.32989682728<!--chord length at tip of horizontal tail--></chord>
+          <chord units="m" is_input="False">1.3281352485615772<!--chord length at tip of horizontal tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">35.73419331459746<!--X-position of leading edge at horizontal tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">4.055028586999011<!--_inp_data:geometry:horizontal_tail:tip:leading_edge:x:local--></local></x>
+          </leading_edge>
         </tip>
       </horizontal_tail>
       <landing_gear>
-        <height units="m">3.04114141042<!--height of landing gear--></height>
+        <height units="m" is_input="False">3.0411414104151127<!--height of landing gear--></height>
       </landing_gear>
       <propulsion>
-        <layout>1.0<!--position of engines (1=under the wing / 2=rear fuselage)--></layout>
+        <layout is_input="True">1.0<!--position of engines (1=under the wing / 2=rear fuselage)--></layout>
         <engine>
-          <count>2.0<!--number of engines--></count>
-          <y_ratio>0.34<!--engine position with respect to total span--></y_ratio>
+          <count is_input="True">2.0<!--number of engines--></count>
+          <y_ratio is_input="True">0.34<!--engine position with respect to total span--></y_ratio>
         </engine>
         <fan>
-          <length units="m">3.12688962389<!--engine length--></length>
+          <length units="m" is_input="False">3.1268896238914476<!--engine length--></length>
         </fan>
         <nacelle>
-          <diameter units="m">2.17224386458<!--nacelle diameter--></diameter>
-          <length units="m">5.21148270649<!--nacelle length--></length>
-          <wetted_area units="m**2">21.6092<!--wetted area of nacelle--></wetted_area>
-          <y units="m">5.97124136879<!--Y-position of nacelle center--></y>
+          <diameter units="m" is_input="False">2.1722438645822235<!--nacelle diameter--></diameter>
+          <length units="m" is_input="False">5.2114827064857465<!--nacelle length--></length>
+          <wetted_area units="m**2" is_input="False">21.6092<!--wetted area of nacelle--></wetted_area>
+          <y units="m" is_input="False">5.975275465106045<!--Y-position of nacelle center--></y>
         </nacelle>
         <pylon>
-          <length units="m">5.73263097713<!--pylon length--></length>
-          <wetted_area units="m**2">7.56322<!--wetted area of pylon--></wetted_area>
+          <length units="m" is_input="False">5.732630977134321<!--pylon length--></length>
+          <wetted_area units="m**2" is_input="False">7.56322<!--wetted area of pylon--></wetted_area>
         </pylon>
       </propulsion>
       <slat>
-        <chord_ratio>0.177<!--mean value of slat chord)/(section chord)--></chord_ratio>
-        <span_ratio>0.9<!--ratio (width of slats)/(total span)--></span_ratio>
+        <chord_ratio is_input="True">0.177<!--mean value of slat chord)/(section chord)--></chord_ratio>
+        <span_ratio is_input="True">0.9<!--ratio (width of slats)/(total span)--></span_ratio>
       </slat>
       <vertical_tail>
-        <area units="m**2">27.8117592633<!--vertical tail area--></area>
-        <aspect_ratio>1.74462618632<!--aspect ratio of vertical tail--></aspect_ratio>
-        <span units="m">6.96571055231<!--vertical tail span--></span>
-        <sweep_0 units="deg">40.514801766<!--sweep angle at leading edge of vertical tail--></sweep_0>
-        <sweep_100 units="deg">13.3465197854<!--sweep angle at trailing edge of vertical tail--></sweep_100>
-        <sweep_25 units="deg">35.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
-        <taper_ratio>0.3<!--taper ratio of vertical tail--></taper_ratio>
-        <thickness_ratio>0.1<!--thickness ratio of vertical tail--></thickness_ratio>
-        <volume_coefficient>0.0998033575769<!--volume coefficient of vertical tail--></volume_coefficient>
-        <wetted_area units="m**2">58.404694453<!--wetted area of vertical tail--></wetted_area>
+        <area units="m**2" is_input="False">27.68760484856992<!--vertical tail area--></area>
+        <aspect_ratio is_input="True">1.74462618632<!--aspect ratio of vertical tail--></aspect_ratio>
+        <span units="m" is_input="False">6.950145352909223<!--vertical tail span--></span>
+        <sweep_0 units="deg" is_input="False">40.51480176597914<!--sweep angle at leading edge of vertical tail--></sweep_0>
+        <sweep_100 units="deg" is_input="False">13.34651978540079<!--sweep angle at trailing edge of vertical tail--></sweep_100>
+        <sweep_25 units="deg" is_input="True">35.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <taper_ratio is_input="True">0.3<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.1<!--thickness ratio of vertical tail--></thickness_ratio>
+        <wetted_area units="m**2" is_input="False">58.14397018199684<!--wetted area of vertical tail--></wetted_area>
         <MAC>
-          <length units="m">4.3785455254<!--mean aerodynamic chord length of vertical tail--></length>
-          <z units="m">2.85772740607<!--Z-position of mean aerodynamic chord of vertical tail--></z>
+          <length units="m" is_input="False">4.368761464807569<!--_inp_data:geometry:vertical_tail:MAC:length--></length>
+          <z units="m" is_input="False">2.8513416832448093<!--Z-position of mean aerodynamic chord of vertical tail--></z>
           <at25percent>
-            <x>
-              <from_wingMAC25 units="m">16.39968432<!--distance along X between 25% MAC of wing and 25% MAC of vertical tail--></from_wingMAC25>
-            </x>
+            <x units="m" is_input="False">33.00648032<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. nose of aircraft--><from_wingMAC25 units="m" is_input="False">16.399684320000002<!--_inp_data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">3.528740447161801<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. leading edge of root chord--></local></x>
           </at25percent>
+          <leading_edge>
+            <x units="m" is_input="False">31.91428995379811<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">2.4365500809599085<!--_inp_data:geometry:vertical_tail:MAC:leading_edge:x:local--></local></x>
+          </leading_edge>
         </MAC>
         <root>
-          <chord units="m">6.14256386657<!--chord length at root of vertical tail--></chord>
+          <chord units="m" is_input="False">6.128838026168894<!--chord length at root of vertical tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">29.4777398728382<local units="m" is_input="False">4.440892098500626e-16<!--X-position of leading edge at vertical tail tip w.r.t. leading edge of root chord--></local></x>
+          </leading_edge>
         </root>
         <tip>
-          <chord units="m">1.84276915997<!--chord length at tip of vertical tail--></chord>
+          <chord units="m" is_input="False">1.838651407850668<!--chord length at tip of vertical tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">35.41683069517797<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">5.939090822339777<!--_inp_data:geometry:vertical_tail:tip:leading_edge:x:local--></local></x>
+          </leading_edge>
         </tip>
       </vertical_tail>
       <wing>
-        <area units="m**2">130.143677034<!--wing reference area--></area>
-        <aspect_ratio>9.48<!--wing aspect ratio--></aspect_ratio>
-        <b_50 units="m">38.1162754641<!--actual length between root and tip along 50% of chord--></b_50>
-        <outer_area units="m**2">105.840377117<!--wing area outside of fuselage--></outer_area>
-        <span units="m">35.1249492282<!--wing span--></span>
-        <sweep_0 units="deg">27.0768380405<!--sweep angle at leading edge of wing--></sweep_0>
-        <sweep_100_inner units="deg">0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
-        <sweep_100_outer units="deg">18.3446480708<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
-        <sweep_25 units="deg">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <virtual_taper_ratio>0.38<!--taper ratio of wing computed from virtual chord--></virtual_taper_ratio>
-        <thickness_ratio>0.12839840881<!--mean thickness ratio of wing--></thickness_ratio>
-        <wetted_area units="m**2">211.680754233<!--wetted area of wing--></wetted_area>
+        <area units="m**2" is_input="False">130.31958336291922<!--wing reference area--></area>
+        <aspect_ratio is_input="True">9.48<!--wing aspect ratio--></aspect_ratio>
+        <b_50 units="m" is_input="False">38.14207005665248<!--actual length between root and tip along 50% of chord--></b_50>
+        <outer_area units="m**2" is_input="False">105.99771323572124<!--wing area outside of fuselage--></outer_area>
+        <span units="m" is_input="False">35.148679206506145<!--wing span--></span>
+        <sweep_0 units="deg" is_input="False">27.07669256968531<!--sweep angle at leading edge of wing--></sweep_0>
+        <sweep_100_inner units="deg" is_input="False">0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
+        <sweep_100_outer units="deg" is_input="False">18.345144006915444<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
+        <sweep_100_ratio is_input="True">0.0<!--ratio inner/outer for sweep angles at trailing edge of wing--></sweep_100_ratio>
+        <sweep_25 units="deg" is_input="True">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <taper_ratio is_input="False">0.2770432482365717<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio is_input="False">0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
+        <virtual_taper_ratio is_input="True">0.38<!--taper ratio of wing computed from virtual root chord--></virtual_taper_ratio>
+        <wetted_area units="m**2" is_input="False">211.99542647144247<!--wetted area of wing--></wetted_area>
         <MAC>
-          <length units="m">4.27205889231<!--length of mean aerodynamic chord of wing--></length>
-          <y units="m">6.8480487576<!--Y-position of mean aerodynamic chord of wing--></y>
+          <length units="m" is_input="False">4.275012578259086<!--_inp_data:geometry:wing:MAC:length--></length>
+          <y units="m" is_input="False">6.852580888040769<!--Y-position of mean aerodynamic chord of wing--></y>
           <at25percent>
-            <x units="m">16.606796<!--X-position of the 25% of mean aerodynamic chord of wing w.r.t. aircraft nose (drives position of wing along fuselage)--></x>
+            <x units="m" is_input="True">16.606796<!--_inp_data:geometry:wing:MAC:at25percent:x--></x>
           </at25percent>
           <leading_edge>
-            <x>
-              <local units="m">2.59243199433<!--X-position of leading edge of mean aerodynamic chord w.r.t. leading edge of root chord--></local>
-            </x>
+            <x units="m" is_input="False">15.538042855435227<local units="m" is_input="False">2.59467774572138<!--_inp_data:geometry:wing:MAC:leading_edge:x:local--></local></x>
           </leading_edge>
         </MAC>
         <kink>
-          <chord units="m">3.61067745362<!--chord length at wing kink--></chord>
-          <span_ratio>0.4<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
-          <thickness_ratio>0.120694504281<!--thickness ratio at wing kink--></thickness_ratio>
-          <y units="m">7.02498984563<!--Y-position of wing kink--></y>
+          <chord units="m" is_input="False">3.613004896259709<!--chord length at wing kink--></chord>
+          <span_ratio is_input="True">0.4<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+          <thickness_ratio is_input="False">0.12069450428120491<!--thickness ratio at wing kink--></thickness_ratio>
+          <y units="m" is_input="False">7.029735841301229<!--Y-position of wing kink--></y>
           <leading_edge>
-            <x>
-              <local units="m">2.58933375006<!--X-position of leading edge at wing kink w.r.t. leading edge of root chord--></local>
-            </x>
+            <x units="m" is_input="False">15.535108852083562<local units="m" is_input="False">2.5917437423697143<!--_inp_data:geometry:wing:kink:leading_edge:x:local--></local></x>
           </leading_edge>
         </kink>
         <root>
-          <chord units="m">6.20001120368<!--chord length at wing root--></chord>
-          <thickness_ratio>0.159214026924<!--thickness ratio at wing root--></thickness_ratio>
-          <virtual_chord units="m">4.52052632603<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
-          <y units="m">1.95994<!--Y-position of wing root--></y>
+          <chord units="m" is_input="False">6.2047486386294235<!--chord length at wing root--></chord>
+          <thickness_ratio is_input="False">0.15921402692414266<!--thickness ratio at wing root--></thickness_ratio>
+          <virtual_chord units="m" is_input="False">4.523641361414057<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
+          <y units="m" is_input="False">1.95994<!--Y-position of wing root--></y>
+          <leading_edge>
+            <x units="m" is_input="False">12.943365109713847</x>
+          </leading_edge>
         </root>
         <tip>
-          <chord units="m">1.71780000389<!--chord length at wing tip--></chord>
-          <thickness_ratio>0.110422631576<!--thickness ratio at wing tip--></thickness_ratio>
-          <y units="m">17.5624746141<!--Y-position of wing tip--></y>
+          <chord units="m" is_input="False">1.718983717337342<!--chord length at wing tip--></chord>
+          <thickness_ratio is_input="False">0.11042263157642153<!--thickness ratio at wing tip--></thickness_ratio>
+          <y units="m" is_input="False">17.574339603253073<!--Y-position of wing tip--></y>
           <leading_edge>
-            <x>
-              <local units="m">7.97626295771<!--X-position of leading edge at wing tip w.r.t. leading edge of root chord--></local>
-            </x>
+            <x units="m" is_input="False">20.925643633222307<local units="m" is_input="False">7.98227852350846<!--_inp_data:geometry:wing:tip:leading_edge:x:local--></local></x>
           </leading_edge>
         </tip>
         <spar_ratio>
           <front>
-            <kink>0.15<!--ratio (front spar position)/(chord length) at wing kink--></kink>
-            <root>0.11<!--ratio (front spar position)/(chord length) at wing root--></root>
-            <tip>0.27<!--ratio (front spar position)/(chord length) at wing tip--></tip>
+            <kink is_input="True">0.15<!--ratio (front spar position)/(chord length) at wing kink--></kink>
+            <root is_input="True">0.11<!--ratio (front spar position)/(chord length) at wing root--></root>
+            <tip is_input="True">0.27<!--ratio (front spar position)/(chord length) at wing tip--></tip>
           </front>
           <rear>
-            <kink>0.66<!--ratio (rear spar position)/(chord length) at wing kink--></kink>
-            <root>0.57<!--ratio (rear spar position)/(chord length) at wing root--></root>
-            <tip>0.56<!--ratio (rear spar position)/(chord length) at wing tip--></tip>
+            <kink is_input="True">0.66<!--ratio (rear spar position)/(chord length) at wing kink--></kink>
+            <root is_input="True">0.57<!--ratio (rear spar position)/(chord length) at wing root--></root>
+            <tip is_input="True">0.56<!--ratio (rear spar position)/(chord length) at wing tip--></tip>
           </rear>
         </spar_ratio>
       </wing>
     </geometry>
-    <propulsion>
-      <MTO_thrust units="N">117880.0<!--maximum thrust of one engine at sea level--></MTO_thrust>
-      <rubber_engine>
-        <bypass_ratio>4.9<!--bypass ratio for rubber engine model--></bypass_ratio>
-        <delta_t4_climb>0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_climb>
-        <delta_t4_cruise>0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_cruise>
-        <design_altitude units="m">10058.4<!--design altitude for rubber engine model--></design_altitude>
-        <maximum_mach>0.85<!--maximum Mach number for rubber engine model--></maximum_mach>
-        <overall_pressure_ratio>32.6<!--Overall pressure ratio for rubber engine model--></overall_pressure_ratio>
-        <turbine_inlet_temperature units="K">1633.0<!--design turbine inlet temperature (T4) for rubber engine model--></turbine_inlet_temperature>
-      </rubber_engine>
-    </propulsion>
+    <handling_qualities>
+      <static_margin is_input="False">0.012648162052125211<!--(X-position of neutral point - X-position of center of gravity ) / (mean aerodynamic chord)--></static_margin>
+    </handling_qualities>
     <load_case>
-      <gust_intensity>0.5</gust_intensity>
+      <gust_intensity is_input="True">0.5<!--a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated--></gust_intensity>
+      <manoeuvre_load_factor is_input="True">2.5<!--limit positive manoeuvring load factor--></manoeuvre_load_factor>
       <lc1>
-        <U_gust units="m/s">15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
-        <Vc_EAS units="m/s">375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
-        <altitude units="m">20000.0<!--altitude for sizing load case 1 (gust with minimum aircraft mass)--></altitude>
+        <U_gust units="m/s" is_input="True">15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
+        <Vc_EAS units="m/s" is_input="True">375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
+        <altitude units="m" is_input="True">20000.0<!--altitude for sizing load case 1 (gust with minimum aircraft mass)--></altitude>
       </lc1>
       <lc2>
-        <U_gust units="m/s">15.25<!--gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)--></U_gust>
-        <Vc_EAS units="m/s">375.0<!--equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)--></Vc_EAS>
-        <altitude units="m">20000.0<!--altitude for sizing load case 2 (gust with maximum aircraft mass)--></altitude>
+        <U_gust units="m/s" is_input="True">15.25<!--gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)--></U_gust>
+        <Vc_EAS units="m/s" is_input="True">375.0<!--equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)--></Vc_EAS>
+        <altitude units="m" is_input="True">20000.0<!--altitude for sizing load case 2 (gust with maximum aircraft mass)--></altitude>
       </lc2>
     </load_case>
+    <propulsion>
+      <MTO_thrust units="N" is_input="True">117880.0<!--maximum thrust of one engine at sea level--></MTO_thrust>
+      <rubber_engine>
+        <bypass_ratio is_input="True">4.9<!--bypass ratio for rubber engine model--></bypass_ratio>
+        <delta_t4_climb is_input="True">0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_climb>
+        <delta_t4_cruise is_input="True">0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_cruise>
+        <design_altitude units="m" is_input="True">10058.4<!--design altitude for rubber engine model--></design_altitude>
+        <maximum_mach is_input="True">0.85<!--maximum Mach number for rubber engine model--></maximum_mach>
+        <overall_pressure_ratio is_input="True">32.6<!--Overall pressure ratio for rubber engine model--></overall_pressure_ratio>
+        <turbine_inlet_temperature units="degK" is_input="True">1633.0<!--design turbine inlet temperature (T4) for rubber engine model--></turbine_inlet_temperature>
+      </rubber_engine>
+    </propulsion>
     <mission>
       <sizing>
-        <fuel units="kg">20461.351721<!--consumed fuel mass during whole mission--></fuel>
-        <fuel_reserve units="kg">3393.8898701<!--mass of fuel reserve--></fuel_reserve>
-        <diversion>
-          <distance units="NM">0.0<!--distance to travel during diversion in sizing mission--></distance>
-          <climb>
-            <duration units="min">0.0<!--duration of diversion climb phase in sizing mission--></duration>
-            <fuel units="kg">0.0<!--mass of consumed fuel during diversion climb phase in sizing mission--></fuel>
-          </climb>
-          <cruise>
-            <duration units="h">0.0<!--duration of diversion cruise phase in sizing mission--></duration>
-            <fuel units="kg">0.0<!--mass of consumed fuel during diversion cruise phase in sizing mission--></fuel>
-          </cruise>
-          <descent>
-            <duration units="min">0.0<!--duration of diversion descent phase in sizing mission--></duration>
-            <fuel units="kg">0.0<!--mass of consumed fuel during diversion descent phase in sizing mission--></fuel>
-          </descent>
-        </diversion>
-        <holding>
-          <CAS units="m/s">0.0<!--Calibrated Air Speed during holding phase in sizing mission--></CAS>
-          <altitude units="ft">0.0<!--altitude during holding phase in sizing mission--></altitude>
-          <duration units="s">0.0<!--duration of holding phase in sizing mission--></duration>
-          <fuel units="kg">0.0<!--mass of consumed fuel during holding phase in sizing mission--></fuel>
-        </holding>
-        <initial_climb>
-          <fuel units="kg">0.0<!--mass of consumed fuel during initial climb phase in sizing mission--></fuel>
-        </initial_climb>
+        <ISA_offset units="degK" is_input="True">0.0<!--Input defined by the mission.--></ISA_offset>
+        <TOW units="kg" is_input="False">77086.92304606961<!--Loaded fuel at beginning for mission "sizing"--></TOW>
+        <ZFW units="kg" is_input="False">56583.56078276247<!--Zero Fuel Weight for mission "sizing"--></ZFW>
+        <block_fuel units="kg" is_input="False">20503.36227063105<!--Loaded fuel at beginning for mission "sizing"_inp_data:mission:sizing:block_fuel--></block_fuel>
+        <consumed_fuel_before_input_weight units="kg" is_input="False">0.0<!--consumed fuel quantity before target mass defined for "sizing", if any (e.g. TakeOff Weight)--></consumed_fuel_before_input_weight>
+        <distance units="m" is_input="False">5093000.0<!--covered ground distance during mission "sizing"--></distance>
+        <duration units="s" is_input="False">19857.45794460585<!--duration of mission "sizing"--></duration>
+        <fuel units="kg" is_input="False">20503.36227063105<!--burned fuel during mission "sizing"--></fuel>
+        <needed_block_fuel units="kg" is_input="False">20503.36227063105<!--Needed fuel to complete mission "sizing", including reserve fuel--></needed_block_fuel>
+        <specific_burned_fuel units="1/nmi" is_input="False">0.0005478959507944804</specific_burned_fuel>
+        <cs25>
+          <load_factor_1 is_input="False">3.75</load_factor_1>
+          <load_factor_2 is_input="False">3.75</load_factor_2>
+          <sizing_load_1 units="kg" is_input="False">246422.7705202372</sizing_load_1>
+          <sizing_load_2 units="kg" is_input="False">259162.7766680397</sizing_load_2>
+        </cs25>
+        <global_reserve>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "global_reserve" in mission "sizing"--></distance>
+          <duration units="s" is_input="False">0.0<!--duration of route "global_reserve" in mission "sizing"--></duration>
+          <fuel units="kg" is_input="False">3395.0136465263204<!--burned fuel during route "global_reserve" in mission "sizing"--></fuel>
+        </global_reserve>
         <landing>
-          <flap_angle units="deg">30.0<!--flap angle during landing phase in sizing mission--></flap_angle>
-          <slat_angle units="deg">20.0<!--slat angle during landing phase in sizing mission--></slat_angle>
+          <flap_angle units="deg" is_input="True">30.0</flap_angle>
+          <slat_angle units="deg" is_input="True">20.0</slat_angle>
         </landing>
-        <takeoff>
-          <TOFL units="m">0.0<!--TakeOff Field Length in sizing mission--></TOFL>
-          <V2 units="m/s">0.0<!--safety speed before reaching 35 feet height in sizing mission--></V2>
-          <VLOF units="m/s">0.0<!--lift-off speed in sizing mission--></VLOF>
-          <VMCA units="m/s">0.0<!--air minimum control speed in sizing mission--></VMCA>
-          <VR units="m/s">0.0<!--rotation speed in sizing mission--></VR>
-          <altitude units="m">0.0<!--altitude at takeoff in sizing mission--></altitude>
-          <delta_ISA units="degC">0.0<!--ISA temperature increment during takeoff phase in sizing mission--></delta_ISA>
-          <duration units="min">0.0<!--duration of takeoff phase in sizing mission--></duration>
-          <flap_angle units="deg">0.0<!--flap angle during takeoff phase in sizing mission--></flap_angle>
-          <friction_coefficient_no_brake>0.0<!--ground friction coefficient with no brake in sizing mission--></friction_coefficient_no_brake>
-          <fuel units="kg">0.0<!--mass of consumed fuel during takeoff phase in sizing mission--></fuel>
-          <slat_angle units="deg">0.0<!--slat angle during takeoff phase in sizing mission--></slat_angle>
-        </takeoff>
-        <taxi_in>
-          <duration units="s">0.0<!--duration of taxi-in phase in sizing mission--></duration>
-          <fuel units="kg">0.0<!--mass of consumed fuel during taxi-in phase in sizing mission--></fuel>
-          <speed units="kn">0.0<!--speed during taxi-in phase in sizing mission--></speed>
-          <thrust_rate>0.0<!--thrust rate (between 0.0 and 1.0) during taxi-in phase in sizing mission--></thrust_rate>
-        </taxi_in>
-        <taxi_out>
-          <duration units="s">0.0<!--duration of taxi-out phase in sizing mission--></duration>
-          <fuel units="kg">0.0<!--mass of consumed fuel during taxi-out phase in sizing mission--></fuel>
-          <speed units="kn">0.0<!--speed during taxi-out phase in sizing mission--></speed>
-          <thrust_rate>0.0<!--thrust rate (between 0.0 and 1.0) during taxi-out phase in sizing mission--></thrust_rate>
-        </taxi_out>
         <main_route>
+          <distance units="m" is_input="False">5093000.0<!--covered ground distance during route "main_route" in mission "sizing"--></distance>
+          <duration units="s" is_input="False">19857.45794460585<!--duration of route "main_route" in mission "sizing"--></duration>
+          <fuel units="kg" is_input="False">17108.34862410473<!--burned fuel during route "main_route" in mission "sizing"--></fuel>
           <climb>
-            <fuel units="kg">2310.78548668<!--mass of consumed fuel during climb phase in sizing mission--></fuel>
+            <distance units="m" is_input="False">250000.0<!--covered ground distance during phase "climb" of route "main_route" in mission "sizing"--></distance>
+            <duration units="s" is_input="False">0.0<!--duration of phase "climb" of route "main_route" in mission "sizing"--></duration>
+            <fuel units="kg" is_input="False">2312.607691382087<!--burned fuel during phase "climb" of route "main_route" in mission "sizing"--></fuel>
           </climb>
           <cruise>
-            <altitude units="ft">35000.0<!--altitude during cruise phase in sizing mission--></altitude>
-            <fuel units="kg">13533.028996<!--mass of consumed fuel during cruise phase in sizing mission--></fuel>
+            <altitude units="ft" is_input="True">35000.0<!--Input defined by the mission.--></altitude>
+            <distance units="m" is_input="False">4593000.0<!--covered ground distance during phase "cruise" of route "main_route" in mission "sizing"--></distance>
+            <duration units="s" is_input="False">19857.45794460585<!--duration of phase "cruise" of route "main_route" in mission "sizing"--></duration>
+            <fuel units="kg" is_input="False">13571.688393498865<!--burned fuel during phase "cruise" of route "main_route" in mission "sizing"--></fuel>
           </cruise>
           <descent>
-            <fuel units="kg">1223.64736813<!--mass of consumed fuel during descent phase in sizing mission--></fuel>
+            <distance units="m" is_input="False">250000.0<!--covered ground distance during phase "descent" of route "main_route" in mission "sizing"--></distance>
+            <duration units="s" is_input="False">0.0<!--duration of phase "descent" of route "main_route" in mission "sizing"--></duration>
+            <fuel units="kg" is_input="False">1224.052539223776<!--burned fuel during phase "descent" of route "main_route" in mission "sizing"--></fuel>
           </descent>
         </main_route>
+        <start>
+          <altitude units="ft" is_input="True">0.0<!--Input defined by the mission.--></altitude>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "start" in mission "sizing"--></distance>
+          <duration units="s" is_input="False">0.0<!--duration of route "start" in mission "sizing"--></duration>
+          <fuel units="kg" is_input="False">0.0<!--burned fuel during route "start" in mission "sizing"--></fuel>
+          <true_airspeed units="m/s" is_input="True">0.0<!--Input defined by the mission.--></true_airspeed>
+        </start>
+        <takeoff>
+          <V2 units="m/s" is_input="True">0.0<!--Input defined by the mission.--></V2>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "takeoff" in mission "sizing"--></distance>
+          <duration units="min" is_input="True">0.0<!--Input defined by the mission.--></duration>
+          <fuel units="kg" is_input="True">0.0<!--Input defined by the mission.--></fuel>
+          <safety_altitude units="ft" is_input="True">35.0<!--Input defined by the mission.--></safety_altitude>
+        </takeoff>
+        <taxi_out>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "taxi_out" in mission "sizing"--></distance>
+          <duration units="s" is_input="True">0.0<!--Input defined by the mission.--></duration>
+          <fuel units="kg" is_input="False">0.0<!--burned fuel during route "taxi_out" in mission "sizing"--></fuel>
+          <thrust_rate is_input="True">0.0<!--Input defined by the mission.--></thrust_rate>
+          <true_airspeed units="m/s" is_input="True">0.0<!--Input defined by the mission.--></true_airspeed>
+        </taxi_out>
       </sizing>
     </mission>
     <weight>
       <aircraft>
-        <MFW units="kg">20465.0406228<!--maximum fuel weight--></MFW>
-        <MLW units="kg">66329.5282097<!--maximum landing weight--></MLW>
-        <MTOW units="kg">77026.1828893<!--maximum takeoff weight--></MTOW>
-        <MZFW units="kg">62575.0266129<!--maximum zero fuel weight--></MZFW>
-        <OWE units="kg">42967.026517<!--operating weight - empty--></OWE>
-        <max_payload units="kg">19608.0<!--max payload weight--></max_payload>
-        <payload units="kg">13608.0<!--design payload weight--></payload>
+        <MFW units="kg" is_input="False">20503.362263307135<!--maximum fuel weight--></MFW>
+        <MLW units="kg" is_input="False">66338.57442972822<!--maximum landing weight--></MLW>
+        <MTOW units="kg" is_input="False">77086.92304606961<!--maximum takeoff weight--></MTOW>
+        <MZFW units="kg" is_input="False">62583.56078276247<!--maximum zero fuel weight--></MZFW>
+        <OWE units="kg" is_input="False">42975.56078276247<!--Mass of crew--></OWE>
+        <additional_fuel_capacity units="kg" is_input="False">-7.323913450818509e-06<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
+        <max_payload units="kg" is_input="False">19608.0<!--max payload weight--></max_payload>
+        <payload units="kg" is_input="False">13608.0<!--_inp_data:weight:aircraft:payload--></payload>
+        <sizing_block_fuel units="kg" is_input="False">20503.36227063105<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>
+        <sizing_onboard_fuel_at_input_weight units="kg" is_input="False">20503.36227063105<!--_inp_data:weight:aircraft:sizing_onboard_fuel_at_input_weight--></sizing_onboard_fuel_at_input_weight>
         <CG>
           <aft>
-            <x units="m">17.3756365402<!--most aft X-position of aircraft center of gravity--></x>
+            <MAC_position is_input="False">0.40811448585698545<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
+            <x units="m" is_input="False">17.28273741584358<!--most aft X-position of aircraft center of gravity--></x>
           </aft>
         </CG>
-      </aircraft>
-      <airframe>
-        <mass units="kg">23747.8211112<!--airframe (A): mass--></mass>
-        <flight_controls>
-          <mass units="kg">769.070449994<!--flight controls (A4): total mass--></mass>
+        <empty>
           <CG>
-            <x units="m">19.1463604863<!--flight controls (A4): X-position of center of gravity--></x>
+            <MAC_position is_input="False">0.35757498027841933<!--X-position of center of gravity as ratio of mean aerodynamic chord for empty aircraft--></MAC_position>
+          </CG>
+        </empty>
+        <load_cases>
+          <CG>
+            <MAC_position is_input="False">[[0.3344061576349848], [0.25616793370146423], [0.35582894571419793], [0.35811448585698546]]<maximum is_input="False">0.35811448585698546</maximum></MAC_position>
+          </CG>
+        </load_cases>
+      </aircraft>
+      <aircraft_empty>
+        <mass units="kg" is_input="False">42505.56076704436<!--mass of empty aircraft (=OWE - mass of crew)--></mass>
+        <CG>
+          <x units="m" is_input="False">17.066680393796215<!--X-position center of gravity of empty aircraft--></x>
+        </CG>
+      </aircraft_empty>
+      <airframe>
+        <mass units="kg" is_input="False">23755.04955102467<!--Mass of airframe--></mass>
+        <flight_controls>
+          <mass units="kg" is_input="False">769.5997397224129<!--Mass of airframe_inp_data:weight:airframe:flight_controls:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">19.14811374834327<!--flight controls (A4): X-position of center of gravity--></x>
           </CG>
         </flight_controls>
         <fuselage>
-          <mass units="kg">8872.59149247<!--fuselage (A2): total mass--></mass>
+          <mass units="kg" is_input="False">8872.865285701002<!--Mass of airframe_inp_data:weight:airframe:fuselage:mass--></mass>
           <CG>
-            <x units="m">16.8783138<!--fuselage (A2): X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.8783138<!--fuselage (A2): X-position of center of gravity--></x>
           </CG>
         </fuselage>
         <horizontal_tail>
-          <mass units="kg">765.813229211<!--horizontal tail (A31): mass--></mass>
+          <mass units="kg" is_input="False">763.2255928719553<!--Mass of airframe_inp_data:weight:airframe:horizontal_tail:mass--></mass>
           <CG>
-            <x units="m">34.5854684312<!--horizontal tail (A31): X-position of center of gravity--></x>
+            <x units="m" is_input="False">33.79593233126773<!--horizontal tail (A31): X-position of center of gravity--></x>
           </CG>
         </horizontal_tail>
         <paint>
-          <mass units="kg">144.287442314<!--paint (A7): total mass--></mass>
+          <mass units="kg" is_input="False">144.2613911166236<!--Mass of airframe_inp_data:weight:airframe:paint:mass--></mass>
           <CG>
-            <x units="m">0.0<!--paint (A7): X-position of center of gravity--></x>
+            <x units="m" is_input="False">0.0<!--paint (A7): X-position of center of gravity--></x>
           </CG>
         </paint>
         <pylon>
-          <mass units="kg">1211.88379531<!--pylon (A6): total mass--></mass>
+          <mass units="kg" is_input="False">1211.8837953053956<!--Mass of airframe_inp_data:weight:airframe:pylon:mass--></mass>
           <CG>
-            <x units="m">13.7472250519<!--pylon (A6): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.746155913953858<!--pylon (A6): X-position of center of gravity--></x>
           </CG>
         </pylon>
         <vertical_tail>
-          <mass units="kg">585.937459189<!--vertical tail (A32): mass--></mass>
+          <mass units="kg" is_input="False">582.627393846386<!--Mass of airframe_inp_data:weight:airframe:vertical_tail:mass--></mass>
           <CG>
-            <x units="m">34.3302767711<!--vertical tail (A32): X-position of center of gravity--></x>
+            <x units="m" is_input="False">33.23512832108261<!--vertical tail (A32): X-position of center of gravity--></x>
           </CG>
         </vertical_tail>
         <wing>
-          <mass units="kg">8834.8657496<!--wing (A1): total mass--></mass>
+          <mass units="kg" is_input="False">8845.195629323802<!--Mass of airframe_inp_data:weight:airframe:wing:mass--></mass>
           <CG>
-            <x units="m">16.7103619021<!--wing (A1): X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.710435497577926<!--wing (A1): X-position of center of gravity--></x>
           </CG>
         </wing>
         <landing_gear>
           <front>
-            <mass units="kg">383.966406678<!--front landing gear (A52): mass--></mass>
+            <mass units="kg" is_input="False">384.2208302629416<!--Mass of airframe_inp_data:weight:airframe:landing_gear:front:mass--></mass>
             <CG>
-              <x units="m">5.176347<!--front landing gear (A52): X-position of center of gravity--></x>
+              <x units="m" is_input="False">5.176347<!--front landing gear (A52): X-position of center of gravity--></x>
             </CG>
           </front>
           <main>
-            <mass units="kg">2179.40508648<!--main landing gear (A51): mass--></mass>
+            <mass units="kg" is_input="False">2181.16989287415<!--Mass of airframe_inp_data:weight:airframe:landing_gear:main:mass--></mass>
             <CG>
-              <x units="m">18.4371054983<!--main landing gear (A51): X-position of center of gravity--></x>
+              <x units="m" is_input="False">18.335467017221283<!--main landing gear (A51): X-position of center of gravity--></x>
             </CG>
           </main>
         </landing_gear>
       </airframe>
       <crew>
-        <mass units="kg">470.0<!--crew (E): mass--></mass>
-        <CG>
-          <x units="m">0.0<!--crew (E): X-position of center of gravity--></x>
-        </CG>
+        <mass units="kg" is_input="False">470.0<!--Mass of crew_inp_data:weight:crew:mass--></mass>
       </crew>
       <furniture>
-        <mass units="kg">3112.5<!--aircraft furniture (D): mass--></mass>
-        <cargo_configuration>
-          <mass units="kg">0.0<!--cargo configuration (D1): mass--></mass>
-          <CG>
-            <x units="m">0.0<!--cargo configuration (D1): X-position of center of gravity--></x>
-          </CG>
-        </cargo_configuration>
+        <mass units="kg" is_input="False">3112.5<!--Mass of aircraft furniture--></mass>
         <food_water>
-          <mass units="kg">1312.5<!--food water (D3): mass--></mass>
+          <mass units="kg" is_input="False">1312.5<!--Mass of aircraft furniture_inp_data:weight:furniture:food_water:mass--></mass>
           <CG>
-            <x units="m">29.403796<!--food water (D3): X-position of center of gravity--></x>
+            <x units="m" is_input="False">29.403796000000007<!--food water (D3): X-position of center of gravity--></x>
           </CG>
         </food_water>
         <passenger_seats>
-          <mass units="kg">1500.0<!--passenger seats (D2): mass--></mass>
+          <mass units="kg" is_input="False">1500.0<!--Mass of aircraft furniture_inp_data:weight:furniture:passenger_seats:mass--></mass>
           <CG>
-            <x units="m">16.616796<!--passenger seats (D2): X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.616796<!--passenger seats (D2): X-position of center of gravity--></x>
           </CG>
         </passenger_seats>
         <security_kit>
-          <mass units="kg">225.0<!--security kit (D4): mass--></mass>
+          <mass units="kg" is_input="False">225.0<!--Mass of aircraft furniture_inp_data:weight:furniture:security_kit:mass--></mass>
           <CG>
-            <x units="m">16.616796<!--security kit (D4): X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.616796<!--security kit (D4): X-position of center of gravity--></x>
           </CG>
         </security_kit>
         <toilets>
-          <mass units="kg">75.0<!--toilets (D5): mass--></mass>
+          <mass units="kg" is_input="False">75.0<!--Mass of aircraft furniture_inp_data:weight:furniture:toilets:mass--></mass>
           <CG>
-            <x units="m">16.616796<!--toilets (D5): X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.616796<!--toilets (D5): X-position of center of gravity--></x>
           </CG>
         </toilets>
       </furniture>
       <propulsion>
-        <mass units="kg">7747.51777042<!--propulsion system (B): mass--></mass>
+        <mass units="kg" is_input="False">7748.006297727328<!--Mass of the propulsion system--></mass>
         <engine>
-          <mass units="kg">7161.3348<!--engine (B1): mass--></mass>
+          <mass units="kg" is_input="False">7161.3348000000005<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
           <CG>
-            <x units="m">13.7472250519<!--engine (B1): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.746155913953858<!--engine (B1): X-position of center of gravity--></x>
           </CG>
         </engine>
         <fuel_lines>
-          <mass units="kg">464.555328239<!--fuel lines (B2): mass--></mass>
+          <mass units="kg" is_input="False">464.9097298057535<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
           <CG>
-            <x units="m">13.7472250519<!--fuel lines (B2): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.746155913953858<!--fuel lines (B2): X-position of center of gravity--></x>
           </CG>
         </fuel_lines>
         <unconsumables>
-          <mass units="kg">121.62764218<!--unconsumables (B3): mass--></mass>
+          <mass units="kg" is_input="False">121.76176792157497<!--Mass of the propulsion system_inp_data:weight:propulsion:unconsumables:mass--></mass>
           <CG>
-            <x units="m">13.7472250519<!--unconsumables (B3): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.746155913953858<!--unconsumables (B3): X-position of center of gravity--></x>
           </CG>
         </unconsumables>
       </propulsion>
       <systems>
-        <mass units="kg">7889.18763535<!--aircraft systems (C): mass--></mass>
+        <mass units="kg" is_input="False">7890.004934010472<!--Mass of aircraft systems--></mass>
         <flight_kit>
-          <mass units="kg">45.0<!--flight kit (C6): mass--></mass>
+          <mass units="kg" is_input="False">45.0<!--Mass of aircraft systems_inp_data:weight:systems:flight_kit:mass--></mass>
           <CG>
-            <x units="m">7.468796<!--flight kit (C6): X-position of center of gravity--></x>
+            <x units="m" is_input="False">7.468795999999999<!--flight kit (C6): X-position of center of gravity--></x>
           </CG>
         </flight_kit>
         <navigation>
-          <mass units="kg">497.178153599<!--navigation (C3): mass--></mass>
+          <mass units="kg" is_input="False">497.210080675836<!--Mass of aircraft systems_inp_data:weight:systems:navigation:mass--></mass>
           <CG>
-            <x units="m">5.5214368<!--navigation (C3): X-position of center of gravity--></x>
+            <x units="m" is_input="False">5.5214368<!--navigation (C3): X-position of center of gravity--></x>
           </CG>
         </navigation>
         <transmission>
-          <mass units="kg">200.0<!--transmission (C4): mass--></mass>
+          <mass units="kg" is_input="False">200.0<!--Mass of aircraft systems_inp_data:weight:systems:transmission:mass--></mass>
           <CG>
-            <x units="m">18.753682<!--transmission (C4): X-position of center of gravity--></x>
+            <x units="m" is_input="False">18.753682<!--transmission (C4): X-position of center of gravity--></x>
           </CG>
         </transmission>
         <life_support>
           <air_conditioning>
-            <mass units="kg">942.401081032<!--air conditioning (C2): mass--></mass>
+            <mass units="kg" is_input="False">942.4010810318936<!--Mass of aircraft systems_inp_data:weight:systems:life_support:air_conditioning:mass--></mass>
             <CG>
-              <x units="m">16.616796<!--air conditioning (C2): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.616796<!--air conditioning (C2): X-position of center of gravity--></x>
             </CG>
           </air_conditioning>
           <cabin_lighting>
-            <mass units="kg">169.676845829<!--cabin lighting (C2): mass--></mass>
+            <mass units="kg" is_input="False">169.67684582876902<!--Mass of aircraft systems_inp_data:weight:systems:life_support:cabin_lighting:mass--></mass>
             <CG>
-              <x units="m">16.8783138<!--cabin lighting (C2): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.8783138<!--cabin lighting (C2): X-position of center of gravity--></x>
             </CG>
           </cabin_lighting>
           <de-icing>
-            <mass units="kg">160.860502722<!--de-icing (C2): mass--></mass>
+            <mass units="kg" is_input="False">160.91105315271096<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de-icing:mass--></mass>
             <CG>
-              <x units="m">15.9659871662<!--de-icing (C2): X-position of center of gravity--></x>
+              <x units="m" is_input="False">15.965544113261137<!--de-icing (C2): X-position of center of gravity--></x>
             </CG>
           </de-icing>
           <insulation>
-            <mass units="kg">2254.27809458<!--insulation (C21): mass--></mass>
+            <mass units="kg" is_input="False">2254.2780945822174<!--Mass of aircraft systems_inp_data:weight:systems:life_support:insulation:mass--></mass>
             <CG>
-              <x units="m">16.8783138<!--insulation (C21): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.8783138<!--insulation (C21): X-position of center of gravity--></x>
             </CG>
           </insulation>
           <oxygen>
-            <mass units="kg">284.1<!--oxygen (C21): mass--></mass>
+            <mass units="kg" is_input="False">284.1<!--Mass of aircraft systems_inp_data:weight:systems:life_support:oxygen:mass--></mass>
             <CG>
-              <x units="m">16.616796<!--oxygen (C21): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.616796<!--oxygen (C21): X-position of center of gravity--></x>
             </CG>
           </oxygen>
           <safety_equipment>
-            <mass units="kg">432.713348<!--safety equipment (C21): mass--></mass>
+            <mass units="kg" is_input="False">432.713348<!--Mass of aircraft systems_inp_data:weight:systems:life_support:safety_equipment:mass--></mass>
             <CG>
-              <x units="m">16.1418867238<!--safety equipment (C21): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.14170978318939<!--safety equipment (C21): X-position of center of gravity--></x>
             </CG>
           </safety_equipment>
           <seats_crew_accommodation>
-            <mass units="kg">126.0<!--seats crew accommodation (C21): mass--></mass>
+            <mass units="kg" is_input="False">126.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:seats_crew_accommodation:mass--></mass>
             <CG>
-              <x units="m">16.616796<!--seats crew accommodation (C21): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.616796<!--seats crew accommodation (C21): X-position of center of gravity--></x>
             </CG>
           </seats_crew_accommodation>
         </life_support>
         <operational>
           <cargo_hold>
-            <mass units="kg">278.319390267<!--cargo hold (C52): mass--></mass>
+            <mass units="kg" is_input="False">278.23070548485737<!--Mass of aircraft systems_inp_data:weight:systems:operational:cargo_hold:mass--></mass>
             <CG>
-              <x units="m">16.616796<!--cargo hold (C52): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.616796<!--cargo hold (C52): X-position of center of gravity--></x>
             </CG>
           </cargo_hold>
           <radar>
-            <mass units="kg">100.0<!--radar (C51): mass--></mass>
+            <mass units="kg" is_input="False">100.0<!--Mass of aircraft systems_inp_data:weight:systems:operational:radar:mass--></mass>
             <CG>
-              <x units="m">0.75014728<!--radar (C51): X-position of center of gravity--></x>
+              <x units="m" is_input="False">0.7501472800000001<!--radar (C51): X-position of center of gravity--></x>
             </CG>
           </radar>
         </operational>
         <power>
           <auxiliary_power_unit>
-            <mass units="kg">287.378465205<!--power (C1): mass--></mass>
+            <mass units="kg" is_input="False">287.3784652052712<!--Mass of aircraft systems_inp_data:weight:systems:power:auxiliary_power_unit:mass--></mass>
             <CG>
-              <x units="m">35.6319958<!--power (C1): X-position of center of gravity--></x>
+              <x units="m" is_input="False">35.6319958<!--power (C1): X-position of center of gravity--></x>
             </CG>
           </auxiliary_power_unit>
           <electric_systems>
-            <mass units="kg">1339.82416131<!--power (C1): mass--></mass>
+            <mass units="kg" is_input="False">1340.3466505852334<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
             <CG>
-              <x units="m">18.753682<!--power (C1): X-position of center of gravity--></x>
+              <x units="m" is_input="False">18.753682<!--power (C1): X-position of center of gravity--></x>
             </CG>
           </electric_systems>
           <hydraulic_systems>
-            <mass units="kg">771.457592806<!--power (C1): mass--></mass>
+            <mass units="kg" is_input="False">771.758609463683<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
             <CG>
-              <x units="m">18.753682<!--power (C1): X-position of center of gravity--></x>
+              <x units="m" is_input="False">18.753682<!--power (C1): X-position of center of gravity--></x>
             </CG>
           </hydraulic_systems>
         </power>
       </systems>
       <fuel_tank>
         <CG>
-          <x units="m">16.0472871741<!--fuel tank: X-position of center of gravity--></x>
+          <x units="m" is_input="False">16.1130986828687<!--fuel tank: X-position of center of gravity--></x>
         </CG>
       </fuel_tank>
       <payload>
         <PAX>
           <CG>
-            <x units="m">16.616796<!--passengers: X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.616796<!--passengers: X-position of center of gravity--></x>
           </CG>
         </PAX>
         <front_fret>
           <CG>
-            <x units="m">9.9240726413<!--front fret: X-position of center of gravity--></x>
+            <x units="m" is_input="False">9.922580554856923<!--front fret: X-position of center of gravity--></x>
           </CG>
         </front_fret>
         <rear_fret>
           <CG>
-            <x units="m">20.8290771228<!--rear fret: X-position of center of gravity--></x>
+            <x units="m" is_input="False">20.829480010308693<!--rear fret: X-position of center of gravity--></x>
           </CG>
         </rear_fret>
       </payload>
@@ -565,60 +587,139 @@
     <aerodynamics>
       <aircraft>
         <cruise>
-          <CL_alpha>6.41777358435<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
-          <L_D_max>16.3739028948<!--max lift/drag ratio in cruise conditions--></L_D_max>
+          <AoA units="rad" is_input="False">[-0.015581773843222275, -0.014023596458900047, -0.01246541907457782, -0.010907241690255592, -0.009349064305933364, -0.007790886921611138, -0.006232709537288911, -0.004674532152966682, -0.0031163547686444554, -0.0015581773843222288, 0.0, 0.0015581773843222266, 0.003116354768644453, 0.004674532152966682, 0.006232709537288911, 0.007790886921611135, 0.009349064305933364, 0.010907241690255592, 0.012465419074577818, 0.014023596458900046, 0.015581773843222275, 0.017139951227544498, 0.01869812861186673, 0.020256305996188956, 0.02181448338051118, 0.02337266076483341, 0.02493083814915564, 0.026489015533477867, 0.028047192917800095, 0.029605370302122316, 0.031163547686444547, 0.032721725070766775, 0.034279902455089, 0.03583807983941123, 0.03739625722373346, 0.038954434608055685, 0.04051261199237791, 0.04207078937670014, 0.04362896676102237, 0.0451871441453446, 0.04674532152966683, 0.04830349891398906, 0.04986167629831127, 0.0514198536826335, 0.05297803106695573, 0.054536208451277955, 0.05609438583560018, 0.05765256321992241, 0.05921074060424464, 0.06076891798856687, 0.0623270953728891, 0.06388527275721133, 0.06544345014153356, 0.06700162752585578, 0.06855980491017802, 0.07011798229450024, 0.07167615967882247, 0.0732343370631447, 0.07479251444746692, 0.07635069183178914, 0.07790886921611137, 0.07946704660043359, 0.08102522398475583, 0.08258340136907806, 0.08414157875340028, 0.08569975613772252, 0.08725793352204474, 0.08881611090636697, 0.0903742882906892, 0.09193246567501143, 0.09349064305933366, 0.09504882044365587, 0.0966069978279781, 0.09816517521230032, 0.09972335259662256, 0.10128152998094478, 0.10283970736526701, 0.10439788474958923, 0.10595606213391147, 0.1075142395182337, 0.10907241690255592, 0.11063059428687816, 0.11218877167120038, 0.11374694905552261, 0.11530512643984482, 0.11686330382416706, 0.11842148120848928, 0.11997965859281151, 0.12153783597713375, 0.12309601336145597, 0.1246541907457782, 0.12621236813010042, 0.12777054551442266, 0.1293287228987449, 0.13088690028306713, 0.13244507766738933, 0.13400325505171154, 0.13556143243603377, 0.137119609820356, 0.13867778720467824, 0.14023596458900048, 0.14179414197332268, 0.14335231935764492, 0.14491049674196715, 0.1464686741262894, 0.14802685151061162, 0.14958502889493383, 0.15114320627925606, 0.1527013836635783, 0.15425956104790053, 0.15581773843222274, 0.15737591581654498, 0.15893409320086718, 0.16049227058518942, 0.16205044796951165, 0.1636086253538339, 0.16516680273815607, 0.1667249801224783, 0.16828315750680053, 0.16984133489112277, 0.171399512275445, 0.1729576896597672, 0.17451586704408945, 0.17607404442841168, 0.17763222181273391, 0.17919039919705612, 0.18074857658137836, 0.1823067539657006, 0.18386493135002283, 0.18542310873434506, 0.18698128611866727, 0.1885394635029895, 0.19009764088731174, 0.19165581827163397, 0.1932139956559562, 0.1947721730402784, 0.19633035042460065, 0.19788852780892288, 0.19944670519324512, 0.20100488257756735, 0.20256305996188956, 0.20412123734621176, 0.205679414730534, 0.2072375921148562, 0.20879576949917844, 0.21035394688350068, 0.2119121242678229, 0.21347030165214514, 0.21502847903646735, 0.2165866564207896]</AoA>
+          <CD is_input="False">[0.02072447917842244, 0.020726680188796958, 0.02073482115899231, 0.020749001223305138, 0.020769319516032083, 0.02079587517146979, 0.02082876732391489, 0.02086809510766402, 0.020913957657013826, 0.020966454106260937, 0.021025683589702, 0.021091745241633642, 0.02116473819635252, 0.021244761588155258, 0.021331914551338496, 0.021426296220198888, 0.021528005729033052, 0.02163714221213764, 0.02175380480380928, 0.021878092638344622, 0.022010104850040298, 0.022149940573192944, 0.02229769894209921, 0.022453479091055724, 0.02261738015435913, 0.022789501266306064, 0.022969941561193162, 0.023158800173317073, 0.023356176236974426, 0.02356216888646186, 0.023776877256076016, 0.024000400480113537, 0.024232837692871056, 0.02447428802864521, 0.024724850621732648, 0.02498462460643, 0.025255838398506578, 0.025540746976339526, 0.025839529715091677, 0.026152421343454874, 0.02647971479018358, 0.026821765285666, 0.02717899584022185, 0.02755190426337812, 0.027941071937274985, 0.028347174614584608, 0.028770995579273234, 0.029213441590110086, 0.02967556212560342, 0.030158572569464158, 0.03066388212330013, 0.031193127414979583, 0.03174821299572124, 0.03233136019752748, 0.03294516616909224, 0.033592675340600356, 0.034277466108593196, 0.03500375621031652, 0.03577653110985127, 0.036601700793576705, 0.037486291731565174, 0.03843868248364531, 0.03946889361667794, 0.04058894538611894, 0.041813300193204485, 0.043159411384619026, 0.04464840580904306, 0.04630593507073544, 0.048163240131615576, 0.05025848647838482, 0.052638443372441425, 0.05536060190599577, 0.05849585424883721, 0.062131892651100654, 0.06637753422354951, 0.07136823993591934, 0.07727317860436857, 0.08430429554021421, 0.09272798998965161, 0.10288019766708817, 0.11518593107216098, 0.13018467333392708, 0.14856348168310124, 0.17120027624373949, 0.19922062620557338, 0.23407247779581636, 0.27762480615635354, 0.33229826762935366, 0.40123879025838877, 0.4885489612528698, 0.5553328778733796, 0.5562667081256677, 0.5572154004244738, 0.5581790539040951, 0.5591577676988279, 0.5601516409429689, 0.5611607727708149, 0.5621852623166623, 0.5632252087148081, 0.5642807110995484, 0.5653518686051802, 0.5664387803660001, 0.5675415455163046, 0.5686602631903906, 0.5697950325225545, 0.570945952647093, 0.572113122698303, 0.5732966418104806, 0.5744966091179229, 0.5757131237549262, 0.5769462848557876, 0.5781961915548032, 0.5794629429862701, 0.5807466382844846, 0.5820473765837435, 0.5833652570183434, 0.5847003787225808, 0.5860528408307528, 0.5874227424771555, 0.5888101827960859, 0.5902152609218404, 0.5916380759887157, 0.5930787271310087, 0.5945373134830156, 0.5960139341790334, 0.5975086883533585, 0.5990216751402876, 0.6005529936741175, 0.6021027430891446, 0.6036710225196658, 0.6052579310999775, 0.6068635679643763, 0.6084880322471592, 0.6101314230826225, 0.611793839605063, 0.6134753809487771, 0.6151761462480618, 0.6168962346372134, 0.6186357452505289, 0.6203947772223046, 0.6221734296868373, 0.6239718017784236, 0.6257899926313603, 0.6276281013799437, 0.6294862271584707, 0.6313644691012379, 0.6332629263425418, 0.6351816980166792, 0.6371208832579469, 0.6390805812006412]<!--Input defined by the mission.--><compressibility is_input="False">[0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.0010276577717950224, 0.0010340721788208763, 0.001044851952266096, 0.001060132686525893, 0.001080108176058095, 0.0011050345169542509, 0.0011352355852374634, 0.0011711100561380642, 0.0012131401774996004, 0.0012619025676975858, 0.0013180813764016425, 0.0013824842280843375, 0.0014560614669572966, 0.0015399293424348073, 0.001635397921828059, 0.0017440046987086473, 0.0018675550899986708, 0.0020081712934038637, 0.002168351323321527, 0.0023510404756398656, 0.002559718012603585, 0.002798502537161831, 0.0030722803790988957, 0.0033868623904974157, 0.0037491759071330683, 0.004167500354537878, 0.00465175716527602, 0.00521386746050672, 0.005868194507169543, 0.006632092517652276, 0.007526589206338793, 0.008577237043191297, 0.009815177855832573, 0.01127847799666732, 0.01301380759279717, 0.015078558602135845, 0.017543524060176063, 0.02049629708275611, 0.02404559564634274, 0.02832678158637488, 0.033508924584714314, 0.03980387081838143, 0.047477920399274925, 0.05686690990750556, 0.06839575270841378, 0.08260383279676002, 0.10017810826896235, 0.1219964001147802, 0.1491841783896485, 0.18318929018648408, 0.2258806115128753, 0.27967869957669433, 0.34772938328721664, 0.43413515071955644, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]<!--increment of drag coefficient due to compressibility effects (shock waves) w.r.t. data:aerodynamics:aircraft:cruise:CL--></compressibility><trim is_input="False">[0.0, 5.89e-06, 1.178e-05, 1.767e-05, 2.356e-05, 2.945e-05, 3.534e-05, 4.123e-05, 4.712e-05, 5.3009999999999996e-05, 5.89e-05, 6.479e-05, 7.068e-05, 7.657000000000001e-05, 8.246e-05, 8.834999999999999e-05, 9.424e-05, 0.00010013, 0.00010601999999999999, 0.00011191, 0.0001178, 0.00012369, 0.00012958, 0.00013547, 0.00014136, 0.00014725, 0.00015314000000000001, 0.00015903, 0.00016492, 0.00017081, 0.00017669999999999999, 0.00018259, 0.00018848, 0.00019437, 0.00020026, 0.00020615000000000002, 0.00021203999999999998, 0.00021793, 0.00022382, 0.00022971000000000002, 0.0002356, 0.00024149000000000002, 0.00024738, 0.00025327, 0.00025916, 0.00026505, 0.00027094, 0.00027683000000000004, 0.00028272, 0.00028861, 0.0002945, 0.00030039, 0.00030628000000000003, 0.00031217, 0.00031806, 0.00032395000000000004, 0.00032984, 0.00033573, 0.00034162, 0.00034751, 0.00035339999999999997, 0.00035929, 0.00036518, 0.00037107, 0.00037696, 0.00038285, 0.00038874, 0.00039463000000000004, 0.00040052, 0.00040641000000000006, 0.00041230000000000005, 0.00041819, 0.00042407999999999996, 0.00042997, 0.00043586, 0.00044175, 0.00044764, 0.00045353, 0.00045942000000000004, 0.00046531000000000003, 0.0004712, 0.00047709000000000006, 0.00048298000000000004, 0.0004888700000000001, 0.00049476, 0.0005006499999999999, 0.00050654, 0.00051243, 0.00051832, 0.00052421, 0.0005301, 0.00053599, 0.00054188, 0.00054777, 0.0005536600000000001, 0.00055955, 0.00056544, 0.00057133, 0.00057722, 0.00058311, 0.000589, 0.00059489, 0.00060078, 0.00060667, 0.0006125600000000001, 0.00061845, 0.00062434, 0.0006302300000000001, 0.00063612, 0.00064201, 0.0006479000000000001, 0.00065379, 0.00065968, 0.0006655700000000001, 0.00067146, 0.0006773500000000001, 0.00068324, 0.0006891299999999999, 0.00069502, 0.00070091, 0.0007067999999999999, 0.00071269, 0.00071858, 0.00072447, 0.00073036, 0.00073625, 0.00074214, 0.00074803, 0.00075392, 0.00075981, 0.0007657, 0.0007715900000000001, 0.00077748, 0.00078337, 0.0007892600000000001, 0.0007951500000000001, 0.00080104, 0.0008069300000000001, 0.0008128200000000001, 0.00081871, 0.0008246000000000001, 0.0008304899999999999, 0.00083638, 0.00084227, 0.0008481599999999999, 0.00085405, 0.00085994, 0.0008658299999999999, 0.00087172, 0.00087761]<!--increment of drag coefficient due to aircraft trim w.r.t. data:aerodynamics:aircraft:cruise:CL--></trim></CD>
+          <CD0 is_input="False">[0.019698950688100094, 0.019691558143439234, 0.01968269844852846, 0.01967247073766441, 0.019660974145143728, 0.019648307805263054, 0.01963457085231902, 0.01961986242060827, 0.019604281644427436, 0.019587927658073163, 0.019570899595842087, 0.019553296592030846, 0.019535217780936084, 0.019516762296854426, 0.019498029274082528, 0.019479117846917023, 0.019460127149654543, 0.019441156316591733, 0.01942230448202523, 0.019403670780251674, 0.019385354345567696, 0.019367454312269945, 0.019350069814655056, 0.01933329998701967, 0.019317243963660417, 0.019302000878873946, 0.01928766986695689, 0.01927435006220589, 0.019262140598917583, 0.019251140611388606, 0.019241449233915603, 0.019233165600795205, 0.01922638884632406, 0.0192212181047988, 0.019217752510516068, 0.0192160911977725, 0.019216333300864735, 0.01921857795408941, 0.019222924291743167, 0.01922947144812264, 0.019238318557524472, 0.019249564754245305, 0.01926330917258177, 0.01927965094683051, 0.019298689211288158, 0.019320523100251362, 0.01934525174801675, 0.019372974288880972, 0.01940378985714066, 0.01943779758709245, 0.01947509661303299, 0.01951578606925891, 0.019559965090066852, 0.019607732809753458, 0.019659188362615362, 0.019714430882949198, 0.019773559505051618, 0.01983667336321925, 0.019903871591748737, 0.01997525332493671, 0.020050917697079826, 0.020130963842474703, 0.02021549089541799, 0.020304597990206324, 0.020398384261136347, 0.020496948842504692, 0.020600390868608, 0.020708809473742915, 0.02082230379220607, 0.020940972958294102, 0.02106491610630365, 0.021194232370531352, 0.021329020885273855, 0.02146938078482779, 0.0216154112034898, 0.021767211275556517, 0.02192488013532459, 0.02208851691709065, 0.02225822075515133, 0.022434090783803286, 0.02261622613734314, 0.022804725950067543, 0.022999689356273126, 0.02320121549025653, 0.02340940348631439, 0.02362435247874335, 0.023846161601840048, 0.024074929989901118, 0.024310756777223205, 0.024553741098102946, 0.024803982086836977, 0.025061578877721938, 0.025326630605054468, 0.02559923640313121, 0.025879495406248794, 0.026167506748703856, 0.026463369564793053, 0.026767182988813004, 0.02707904615506036, 0.027399058197831755, 0.027727318251423827, 0.028063925450133212, 0.028408978928256563, 0.028762577820090503, 0.029124821259931676, 0.029495808382076716, 0.02987563832082227, 0.030264410210464984, 0.030662223185301478, 0.03106917637962838, 0.03148536892774236, 0.03191089996394006, 0.032345868622518086, 0.03279037403777311, 0.03324451534400172, 0.03370839167550061, 0.03418210216656639, 0.034665745951495706, 0.035159422164585195, 0.03566322994013151, 0.036177268412431275, 0.03670163671578112, 0.03723643398447771, 0.037781759352817655, 0.0383377119550976, 0.03890439092561421, 0.03948189539866408, 0.040070324508543885, 0.04066977738955025, 0.04128035317597982, 0.04190215100212921, 0.0425352700022951, 0.0431798093107741, 0.043835868061862855, 0.044503545389858, 0.04518294042905618, 0.04587415231375404, 0.046577280178248186, 0.04729242315683529, 0.048019680383811984, 0.048759150993474894, 0.04951093412012067, 0.05027512889804594, 0.05105183446154738, 0.05184114994492158, 0.052643174482465194, 0.053458007208474864, 0.05428574725724724, 0.05512649376307895, 0.05598034586026665]<!--profile drag coefficient for whole aircraft in cruise conditions w.r.t. data:aerodynamics:aircraft:cruise:CL--><clean is_input="False">[0.017794697396684836, 0.01778801947270227, 0.01778001622458716, 0.017770777203546487, 0.01776039196078723, 0.017748950047516372, 0.017736541014940883, 0.017723254414267746, 0.017709179796703934, 0.01769440671345643, 0.017679024715732208, 0.017663123354738245, 0.017646792181681525, 0.01763012074776902, 0.01761319860420771, 0.01759611530220458, 0.017578960392966594, 0.017561823427700744, 0.017544793957613998, 0.017527961533913335, 0.017511415707805737, 0.01749524603049818, 0.01747954205319764, 0.0174643933271111, 0.017449889403445534, 0.01743611983340792, 0.017423174168205238, 0.017411141959044463, 0.017400112757132578, 0.017390176113676555, 0.017381421579883375, 0.017373938706960013, 0.017367817046113454, 0.017363146148550668, 0.01736001556547864, 0.017358514848104342, 0.017358733547634755, 0.017360761215276854, 0.017364687402237622, 0.017370601659724032, 0.017378593538943065, 0.0173887525911017, 0.017401168367406912, 0.017415930419065678, 0.017433128297284977, 0.01745285155327179, 0.01747518973823309, 0.017500232403375865, 0.01752806909990708, 0.017558789379033716, 0.01759248279196276, 0.01762923888990118, 0.017669147224055954, 0.01771229734563407, 0.017758778805842496, 0.017808681155888212, 0.0178620939469782, 0.017919106730319434, 0.017979809057118892, 0.018044290478583552, 0.0181126405459204, 0.018184948810336398, 0.018261304823038536, 0.01834179813523379, 0.018426518298129135, 0.018515554862931553, 0.01860899738084802, 0.01870693540308551, 0.01880945848085101, 0.01891665616535149, 0.01902861800779393, 0.019145433559385305, 0.0192671923713326, 0.019393983994842788, 0.01952589798112285, 0.01966302388137976, 0.0198054512468205, 0.019953269628652046, 0.020106568578081373, 0.020265437646315467, 0.020429966384561297, 0.02060024434402585, 0.020776361075916093, 0.020958406131439015, 0.021146469061801582, 0.02134063941821078, 0.02154100675187359, 0.02174766061399698, 0.021960690555787938, 0.022180186128453436, 0.022406236883200453, 0.02263893237123597, 0.02287836214376696, 0.023124615752000404, 0.02337778274714328, 0.023637952680402557, 0.023905215102985232, 0.024179659566098265, 0.024461375620948644, 0.024750452818743343, 0.02504698071068934, 0.02535104884799361, 0.025662746781863144, 0.025982164063504908, 0.026309390244125878, 0.026644514874933037, 0.026987627507133367, 0.027338817691933845, 0.027698174980541442, 0.028065788924163126, 0.028441749074005897, 0.02882614498127674, 0.0292190661971826, 0.029620602272930483, 0.030030842759727335, 0.03044987720878017, 0.03087779517129595, 0.03131468619848165, 0.03176063984154425, 0.03221574565169074, 0.032680093180128086, 0.03315377197806326, 0.03363687159670326, 0.034129481587255046, 0.0346316915009256, 0.035143590888921904, 0.03566526930245092, 0.036196816292719654, 0.03673832141093506, 0.03728987420830414, 0.037851564236033836, 0.038423481045331165, 0.03900571418740308, 0.039598353213456575, 0.04020148767469861, 0.040815207122336175, 0.04143960110757625, 0.0420747591816258, 0.04272077089569181, 0.043377725800981266, 0.044045713448701125, 0.044724823390058385, 0.045415145176260004, 0.046116768358513006, 0.046829782488024316, 0.04755427711600093, 0.04829034179364983, 0.04903806607217799, 0.0497975395027924, 0.05056885163670004]<!--like data:aerodynamics:aircraft:cruise:CD0 but without parasitic drag--></clean><parasitic is_input="False">[0.001904253291415258, 0.0019035386707369657, 0.0019026822239412988, 0.001901693534117923, 0.0019005821843564967, 0.0018993577577466822, 0.001898029837378138, 0.0018966080063405229, 0.0018951018477235022, 0.0018935209446167348, 0.001891874880109879, 0.0018901732372926007, 0.0018884255992545583, 0.001886641549085407, 0.0018848306698748159, 0.0018830025447124435, 0.0018811667566879485, 0.0018793328888909895, 0.001877510524411232, 0.0018757092463383383, 0.00187393863776196, 0.0018722082817717658, 0.0018705277614574148, 0.0018689066599085688, 0.001867354560214883, 0.0018658810454660266, 0.001864495698751651, 0.0018632081031614255, 0.001862027841785005, 0.0018609644977120518, 0.0018600276540322279, 0.001859226893835192, 0.001858571800210606, 0.001858071956248132, 0.001857736945037429, 0.0018575763496681587, 0.0018575997532299798, 0.0018578167388125545, 0.0018582368895055448, 0.0018588697883986094, 0.0018597250185814068, 0.0018608121631436061, 0.001862140805174859, 0.001863720527764831, 0.001865560914003181, 0.0018676715469795706, 0.0018700620097836587, 0.0018727418855051074, 0.0018757207572335823, 0.0018790082080587349, 0.001882613821070231, 0.0018865471793577324, 0.001890817866010898, 0.0018954354641193896, 0.0019004095567728661, 0.001905749727060986, 0.0019114655580734184, 0.001917566632899815, 0.0019240625346298446, 0.001930962846353159, 0.0019382771511594274, 0.0019460150321383048, 0.0019541860723794532, 0.001962799854972535, 0.001971865963007212, 0.0019813939795731393, 0.0019913934877599827, 0.0020018740706574042, 0.002012845311355059, 0.0020243167929426126, 0.00203629809850972, 0.002048798811146047, 0.002061828513941256, 0.002075396789985001, 0.002089513222366949, 0.0021041873941767576, 0.0021194288885040893, 0.0021352472884386027, 0.0021516521770699563, 0.0021686531374878193, 0.0021862597527818432, 0.0022044816060416937, 0.002223328280357033, 0.0022428093588175158, 0.002262934424512808, 0.0022837130605325683, 0.0023051548499664586, 0.0023272693759041375, 0.0023500662214352673, 0.00237355496964951, 0.002397745203636524, 0.0024226465064859683, 0.002448268461287508, 0.002474620651130806, 0.002501712659105513, 0.0025295540683012985, 0.002558154461807821, 0.0025875234227147395, 0.0026176705341117157, 0.0026486053790884118, 0.0026803375407344864, 0.0027128766021396016, 0.0027462321463934194, 0.002780413756585595, 0.002815431015805798, 0.002851293507143679, 0.0028880108136889043, 0.0029255925185311393, 0.0029640482047600357, 0.0030033874554652555, 0.0030436198537364643, 0.003084754982663321, 0.003126802425335487, 0.003169771764842625, 0.003213672584274383, 0.0032585144667204406, 0.0033043069952704424, 0.0033510597530140573, 0.003398782323040944, 0.003447484288440772, 0.0034971752323031888, 0.003547864737717857, 0.003599562387774445, 0.0036522777655626087, 0.003706020454172003, 0.0037608000366923036, 0.003816626096213159, 0.003873508215824231, 0.003931455978615189, 0.003990478967675681, 0.0040505867660953765, 0.004111788956963937, 0.0041740951233710175, 0.0042375148484062805, 0.004302057715159388, 0.004367733306720002, 0.004434551206177785, 0.004502520996622385, 0.004571652261143477, 0.004641954582830718, 0.004713437544773769, 0.004786110730062285, 0.004859983721785935, 0.0049350661030343745, 0.005011367456897266, 0.005088897366464264, 0.005167665414825037, 0.005247681185069249, 0.005328954260286553, 0.0054114942235666125]<!--estimated parasitic drag for whole aircraft in cruise conditions (no high-lift) w.r.t. data:aerodynamics:aircraft:low_speed:CL--></parasitic></CD0>
+          <CL is_input="False">[0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35000000000000003, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41000000000000003, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47000000000000003, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.5700000000000001, 0.58, 0.59, 0.6, 0.61, 0.62, 0.63, 0.64, 0.65, 0.66, 0.67, 0.68, 0.6900000000000001, 0.7000000000000001, 0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79, 0.8, 0.81, 0.8200000000000001, 0.8300000000000001, 0.84, 0.85, 0.86, 0.87, 0.88, 0.89, 0.9, 0.91, 0.92, 0.93, 0.9400000000000001, 0.9500000000000001, 0.96, 0.97, 0.98, 0.99, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08, 1.09, 1.1, 1.11, 1.12, 1.1300000000000001, 1.1400000000000001, 1.1500000000000001, 1.16, 1.17, 1.18, 1.19, 1.2, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.3, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36, 1.37, 1.3800000000000001, 1.3900000000000001, 1.4000000000000001, 1.41, 1.42, 1.43, 1.44, 1.45, 1.46, 1.47, 1.48, 1.49]<!--Input defined by the mission.--></CL>
+          <CL0 is_input="True">0.1</CL0>
+          <CL_alpha units="1/rad" is_input="False">6.4177545513213685<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
+          <L_D_max is_input="False">16.392752942096493<!--max lift/drag ratio in cruise conditions--></L_D_max>
+          <induced_drag_coefficient is_input="False">0.04256959810776591<!--multiply squared lift coefficient by this coefficient to get induced drag coefficient--></induced_drag_coefficient>
+          <optimal_CD is_input="False">0.03233136019752748<!--drag coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CD>
+          <optimal_CL is_input="False">0.53<!--lift coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CL>
+          <oswald_coefficient is_input="False">0.7827637261154686<!--Oswald coefficient for cruise conditions--></oswald_coefficient>
         </cruise>
         <landing>
-          <CL_max>2.80400435071<!--maximum lift coefficient in landing conditions--></CL_max>
-          <CL_max_clean>1.5860839427<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
-          <CL_max_clean_2D>1.94</CL_max_clean_2D>
+          <CL_max is_input="False">2.8004141748800144<!--maximum lift coefficient in landing conditions--></CL_max>
+          <CL_max_clean is_input="False">1.5824133961659907<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
+          <CL_max_clean_2D is_input="True">1.94<!--maximum lift coefficient of 2D average profile in landing conditions without high-lift devices--></CL_max_clean_2D>
+          <additional_CL_capacity is_input="False">0.12642476969938432<!--at landing, is equal to (maximum lift coefficient)-(maximum required lift coefficient)--></additional_CL_capacity>
+          <mach is_input="False">0.19455259748464468<!--considered Mach number for landing phase--></mach>
         </landing>
-        <takeoff>
-          <CL0_clean>0.02228<!--value of lift coefficient at angle of attack 0 in clean configuration at takeoff--></CL0_clean>
-        </takeoff>
       </aircraft>
+      <cruise>
+        <neutral_point>
+          <x is_input="False">0.42076264790911067<!--X-position of neutral point - X-position of aircraft nose--></x>
+        </neutral_point>
+      </cruise>
+      <fuselage>
+        <cruise>
+          <CD0 is_input="False">[0.007141580840659627, 0.007122226202471632, 0.00710304240114483, 0.007084029436679223, 0.007065187309074808, 0.007046516018331587, 0.00702801556444956, 0.007009685947428727, 0.006991527167269088, 0.006973539223970642, 0.00695572211753339, 0.006938075847957331, 0.006920600415242467, 0.006903295819388796, 0.0068861620603963185, 0.006869199138265034, 0.006852407052994945, 0.006835785804586048, 0.006819335393038346, 0.0068030558183518365, 0.006786947080526522, 0.0067710091795624, 0.006755242115459472, 0.006739645888217738, 0.006724220497837197, 0.00670896594431785, 0.0066938822276596975, 0.0066789693478627385, 0.0066642273049269726, 0.0066496560988524005, 0.0066352557296390224, 0.006621026197286837, 0.006606967501795846, 0.006593079643166049, 0.006579362621397446, 0.0065658164364900354, 0.006552441088443819, 0.006539236577258797, 0.006526202902934968, 0.006513340065472333, 0.006500648064870891, 0.0064881269011306435, 0.00647577657425159, 0.006463597084233729, 0.006451588431077062, 0.0064397506147815895, 0.00642808363534731, 0.006416587492774225, 0.006405262187062333, 0.006394107718211634, 0.00638312408622213, 0.006372311291093819, 0.0063616693328267014, 0.006351198211420778, 0.006340897926876048, 0.006330768479192512, 0.006320809868370169, 0.006311022094409021, 0.0063014051573090655, 0.006291959057070305, 0.006282683793692736, 0.006273579367176363, 0.006264645777521182, 0.006255883024727195, 0.006247291108794403, 0.006238870029722804, 0.006230619787512398, 0.006222540382163186, 0.006214631813675168, 0.006206894082048343, 0.006199327187282713, 0.006191931129378276, 0.006184705908335032, 0.0061776515241529825, 0.006170767976832126, 0.006164055266372464, 0.0061575133927739955, 0.00615114235603672, 0.006144942156160639, 0.006138912793145751, 0.0061330542669920576, 0.006127366577699557, 0.00612184972526825, 0.006116503709698138, 0.006111328530989219, 0.006106324189141493, 0.006101490684154961, 0.006096828016029623, 0.006092336184765479, 0.006088015190362528, 0.006083865032820771, 0.006079885712140208, 0.006076077228320838, 0.006072439581362663, 0.00606897277126568, 0.006065676798029891, 0.006062551661655297, 0.006059597362141895, 0.006056813899489688, 0.006054201273698674, 0.006051759484768854, 0.006049488532700227, 0.006047388417492795, 0.006045459139146555, 0.00604370069766151, 0.006042113093037658, 0.006040696325275, 0.006039450394373536, 0.0060383753003332655, 0.0060374710431541885, 0.0060367376228363055, 0.006036175039379615, 0.00603578329278412, 0.006035562383049818, 0.006035512310176709, 0.006035633074164794, 0.006035924675014073, 0.006036387112724546, 0.006037020387296212, 0.006037824498729072, 0.006038799447023125, 0.006039945232178373, 0.006041261854194814, 0.006042749313072448, 0.006044407608811277, 0.006046236741411299, 0.006048236710872515, 0.006050407517194925, 0.006052749160378528, 0.006055261640423325, 0.006057944957329315, 0.006060799111096499, 0.0060638241017248766, 0.006067019929214448, 0.006070386593565214, 0.006073924094777173, 0.006077632432850325, 0.006081511607784672, 0.0060855616195802115, 0.006089782468236945, 0.0060941741537548725, 0.006098736676133994, 0.006103470035374309, 0.006108374231475817, 0.00611344926443852, 0.006118695134262415, 0.006124111840947504, 0.006129699384493788, 0.006135457764901265, 0.006141386982169935]<!--profile drag coefficient for fuselage w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
+          <CnBeta is_input="False">-0.10154900016064428<!--derivative of yawing moment against sideslip angle for fuselage in cruise conditions--></CnBeta>
+        </cruise>
+      </fuselage>
+      <high_lift_devices>
+        <landing>
+          <CD is_input="False">0.03309219200000092<!--increment of CD due to high-lift devices for landing phase--></CD>
+          <CL is_input="False">1.218000778714024<!--increment of CL due to high-lift devices for landing phase--></CL>
+        </landing>
+      </high_lift_devices>
       <horizontal_tail>
         <cruise>
-          <CL_alpha>3.46981756498<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in cruise conditions--></CL_alpha>
+          <CD0 is_input="False">0.0017542856255862048<!--profile drag coefficient for horizontal tail in cruise conditions--></CD0>
+          <CL_alpha units="1/rad" is_input="False">3.4698175649817595<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in cruise conditions--></CL_alpha>
         </cruise>
       </horizontal_tail>
+      <nacelles>
+        <cruise>
+          <CD0 is_input="False">0.0015494146574837723<!--profile drag coefficient for nacelles in cruise conditions--></CD0>
+        </cruise>
+      </nacelles>
+      <pylons>
+        <cruise>
+          <CD0 is_input="False">0.0003279580607410157<!--profile drag coefficient for pylons in cruise conditions--></CD0>
+        </cruise>
+      </pylons>
       <vertical_tail>
         <cruise>
-          <CL_alpha>2.54615644328<!--derivative of lift coefficient of horizontal tail with respect to local "angle of attack" in cruise conditions--></CL_alpha>
+          <CD0 is_input="False">0.0013127123388374106<!--profile drag coefficient for vertical tail in cruise conditions--></CD0>
+          <CL_alpha units="1/rad" is_input="False">2.546156443275808<!--derivative of lift coefficient of horizontal tail with respect to local "angle of attack" in cruise conditions--></CL_alpha>
+          <CnBeta units="m**2" is_input="False">0.2419957361606443<!--derivative of yawing moment against sideslip angle for vertical tail in cruise conditions--></CnBeta>
         </cruise>
       </vertical_tail>
+      <wing>
+        <cruise>
+          <CD0 is_input="False">[0.005708745873376808, 0.005721422587582233, 0.005732603140793926, 0.005742377084218863, 0.005750833969064022, 0.005758063346536382, 0.005764154767842921, 0.0057691977841906154, 0.0057732819467864425, 0.005776496806837382, 0.005778931915550413, 0.005780676824132511, 0.005781821083790655, 0.005782454245731822, 0.005782665861162992, 0.0057825454812911415, 0.005782182657323248, 0.005781666940466291, 0.005781087881927248, 0.005780535032913095, 0.0057800979446308125, 0.005779866168287377, 0.005779929255089767, 0.005780376756244959, 0.005781298222959934, 0.005782783206441666, 0.005784921257897138, 0.005787801928533322, 0.005791514769557201, 0.005796149332175752, 0.0058017951675959495, 0.005808541827024774, 0.005816478861669205, 0.005825695822736217, 0.005836282261432791, 0.0058483277289659045, 0.005861921776542532, 0.005877153955369655, 0.0058941138166542515, 0.005912890911603297, 0.0059335747914237725, 0.005956255007322653, 0.005981021110506918, 0.006007962652183545, 0.006037169183559513, 0.006068730255841799, 0.006102735420237379, 0.006139274227953236, 0.006178436230196344, 0.006220310978173681, 0.006264988023092227, 0.006312556916158957, 0.006363107208580851, 0.006416728451564887, 0.006473510196318045, 0.006533541994047297, 0.0065969133959596265, 0.00666371395326201, 0.006734033217161424, 0.006807960738864846, 0.006885586069579258, 0.006966998760511633, 0.007052288362868952, 0.007141544427858191, 0.0072348565066863305, 0.007332314150560347, 0.007434006910687219, 0.007540024338273923, 0.007650455984527439, 0.007765391400654743, 0.007884920137862813, 0.008009131747358627, 0.008138115780349165, 0.008271961788041404, 0.00841075932164232, 0.008554597932358894, 0.008703567171398103, 0.008857756589966922, 0.009017255739272333, 0.009182154170521314, 0.009352541434920838, 0.009528507083677888, 0.00971014066799944, 0.009897531739092472, 0.010090769848163959, 0.010289944546420885, 0.010495145385070223, 0.010706461915318953, 0.010923983688374056, 0.011147800255442505, 0.011378001167731279, 0.011614675976447357, 0.01185791423279772, 0.012107805487989337, 0.012364439293229198, 0.012627905199724263, 0.012898292758681531, 0.013175691521307965, 0.013460191038810552, 0.013751880862396267, 0.014050850543272085, 0.014357189632644981, 0.014670987681721946, 0.014992334241709948, 0.015321318863815965, 0.015658031099246975, 0.016002560499209964, 0.016354996614911906, 0.016715428997559775, 0.017083947198360535, 0.01746064076852119, 0.01784559925924872, 0.018238912221750076, 0.01864066920723226, 0.019050959766902225, 0.019469873451966973, 0.019897499813633472, 0.0203339284031087, 0.02077924877159964, 0.021233550470313268, 0.021696923050456562, 0.022169456063236486, 0.02265123905986004, 0.023142361591534193, 0.023642913209465922, 0.024152983464862204, 0.024672661908930003, 0.025202038092876328, 0.025741201567908135, 0.026290241885232418, 0.026849248596056124, 0.027418311251586266, 0.02799751940302981, 0.028586962601593727, 0.029186730398485, 0.029796912344910605, 0.030417597992077525, 0.031048876891192727, 0.0316908385934632, 0.03234357265009592, 0.033007168612297855, 0.03368171603127599, 0.0343673044582373, 0.03506402344438879, 0.035771962540937396, 0.036491211299090116, 0.03722185927005392, 0.037963996005035805, 0.038717711055242736, 0.039483093971881704]<!--profile drag coefficient for wing w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
+          <reynolds is_input="False">6124998.624249204<!--Reynolds number based on wing mean aerodynamic chord in cruise conditions--></reynolds>
+        </cruise>
+        <landing>
+          <reynolds is_input="False">18164483.56108458<!--Reynolds number based on wing mean aerodynamic chord in landing conditions--></reynolds>
+        </landing>
+      </wing>
     </aerodynamics>
   </data>
   <settings>
+    <geometry>
+      <horizontal_tail>
+        <position_ratio_on_VTP is_input="True">0.15<!--(applies only for T-tails) distance between HTP root leadingedge and VTP tip leading edge divided by VTP tip chord--></position_ratio_on_VTP>
+        <position_ratio_on_fuselage is_input="True">0.91<!--(does not apply for T-tails) distance to aircraft nose of 25% MAC of horizontal tail divided by fuselage length--></position_ratio_on_fuselage>
+      </horizontal_tail>
+      <vertical_tail>
+        <position_ratio_on_fuselage is_input="True">0.88<!--distance to aircraft nose of 25% MAC of vertical tail divided by fuselage length--></position_ratio_on_fuselage>
+      </vertical_tail>
+    </geometry>
+    <aerodynamics>
+      <wing>
+        <CD>
+          <fuselage_interaction is_input="True">0.04</fuselage_interaction>
+        </CD>
+      </wing>
+    </aerodynamics>
     <weight>
       <aircraft>
         <CG>
-          <range>0.3<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+          <range is_input="True">0.3<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+          <aft>
+            <MAC_position>
+              <margin is_input="True">0.05<!--Added margin for getting most aft CG position, as ratio of mean aerodynamic chord--></margin>
+            </MAC_position>
+          </aft>
         </CG>
+        <payload>
+          <design_mass_per_passenger units="kg" is_input="True">90.72<!--Design value of mass per passenger--></design_mass_per_passenger>
+          <max_mass_per_passenger units="kg" is_input="True">130.72<!--Maximum value of mass per passenger--></max_mass_per_passenger>
+        </payload>
       </aircraft>
       <airframe>
         <flight_controls>
           <mass>
-            <k_fc>0.000135<!--flight controls (A4): 0.85e-4 if electrical, 1.35e-4 if conventional--></k_fc>
+            <k_fc is_input="True">0.000135<!--flight controls (A4): 0.85e-4 if electrical, 1.35e-4 if conventional--></k_fc>
           </mass>
         </flight_controls>
         <fuselage>
           <mass>
-            <k_fus>1.0<!--correction coefficient: 1.00 if all engines under wing / 1.02 with 2 engines at rear / 1.03 if 3 engines at rear / 1.05 if 1 engine in vertical tail (with or without 2 engines under wing)--></k_fus>
-            <k_lg>1.05<!--correction coefficient: 1.05 if main landing gear under wing / 1.10 if main landing gear under fuselage--></k_lg>
+            <k_fus is_input="True">1.0<!--correction coefficient: 1.00 if all engines under wing / 1.02 with 2 engines at rear / 1.03 if 3 engines at rear / 1.05 if 1 engine in vertical tail (with or without 2 engines under wing)--></k_fus>
+            <k_lg is_input="True">1.05<!--correction coefficient: 1.05 if main landing gear under wing / 1.10 if main landing gear under fuselage--></k_lg>
           </mass>
         </fuselage>
+        <landing_gear>
+          <front>
+            <weight_ratio is_input="True">0.08<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <CG>
+              <position_ratio_on_front_fuselage is_input="True">0.75<!--x-distance between nose and front landing gear divided by data:geometry:fuselage:front_length--></position_ratio_on_front_fuselage>
+            </CG>
+          </front>
+        </landing_gear>
         <wing>
           <mass>
-            <k_mvo>1.39<!--1.39 for Airbus type aircrafts--></k_mvo>
-            <k_voil>1.05<!--1.00 if 4 engines / 1.05 if 2 or 3 engines / 1.10 if engines on fuselage--></k_voil>
+            <k_mvo is_input="True">1.39<!--1.39 for Airbus type aircrafts--></k_mvo>
           </mass>
         </wing>
       </airframe>
       <systems>
         <power>
           <mass>
-            <k_elec>1.0<!--electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)--></k_elec>
+            <k_elec is_input="True">1.0<!--electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)--></k_elec>
           </mass>
         </power>
       </systems>
@@ -627,268 +728,287 @@
       <sizing>
         <breguet>
           <climb>
-            <mass_ratio is_input="True">0.97<!--For Breguet performance computation: assumption of (mass at end of climb) / (mass at start of climb)--></mass_ratio>
+            <mass_ratio is_input="True">0.97<!--Input defined by the mission.--></mass_ratio>
           </climb>
           <descent>
-            <mass_ratio is_input="True">0.98<!--For Breguet performance computation: assumption of (mass at end of descent) / (mass at start of descent)--></mass_ratio>
+            <mass_ratio is_input="True">0.98<!--Input defined by the mission.--></mass_ratio>
           </descent>
           <reserve>
-            <mass_ratio is_input="True">0.06<!--For Breguet performance computation: (weight of fuel reserve)/ZFW--></mass_ratio>
+            <mass_ratio is_input="True">0.06<!--Input defined by the mission.--></mass_ratio>
           </reserve>
         </breguet>
       </sizing>
     </mission>
-
   </settings>
   <tuning>
+    <propulsion>
+      <rubber_engine>
+        <SFC>
+          <k_cr is_input="True">1.0<!--correction ratio to apply to the computed SFC at cruise ceiling--></k_cr>
+          <k_sl is_input="True">1.0<!--correction ratio to apply to the computed SFC at sea level--></k_sl>
+        </SFC>
+      </rubber_engine>
+    </propulsion>
     <aerodynamics>
       <aircraft>
         <cruise>
           <CD>
-            <k>1.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></k>
-            <offset>0.0<!--correction offset to apply to computed drag coefficient in cruise conditions--></offset>
+            <k is_input="True">1.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></k>
+            <offset is_input="True">0.0<!--correction offset to apply to computed drag coefficient in cruise conditions--></offset>
+            <compressibility>
+              <characteristic_mach_increment is_input="True">0.0<!--Increment to apply to the computed characteristic Mach (where compressibility drag is 20 d.c.)--></characteristic_mach_increment>
+              <max_value is_input="True">0.5<!--maximum authorized value for compressibility drag. Allows to prevent the model from overestimating the compressibility effect, especially for aircraft models after year 2000.--></max_value>
+            </compressibility>
             <winglet_effect>
-              <k>0.87<!--correction ratio to apply to computed induced drag coefficient in cruise conditions--></k>
-              <offset>0.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></offset>
+              <k is_input="True">0.87<!--correction ratio to apply to computed induced drag coefficient in cruise conditions--></k>
+              <offset is_input="True">0.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></offset>
             </winglet_effect>
           </CD>
           <CL>
-            <k>1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
-            <offset>0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
+            <k is_input="True">1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
+            <offset is_input="True">0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
             <winglet_effect>
-              <k>1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
-              <offset>0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
+              <k is_input="True">1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
+              <offset is_input="True">0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
             </winglet_effect>
           </CL>
         </cruise>
         <landing>
           <CL_max>
             <landing_gear_effect>
-              <k>1.0<!--correction ratio to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear--></k>
+              <k is_input="True">1.0<!--correction ratio to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear--></k>
             </landing_gear_effect>
           </CL_max>
         </landing>
       </aircraft>
+      <high_lift_devices>
+        <landing>
+          <CD>
+            <multi_slotted_flap_effect>
+              <k is_input="True">1.0<!--correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps--></k>
+            </multi_slotted_flap_effect>
+          </CD>
+          <CL>
+            <multi_slotted_flap_effect>
+              <k is_input="True">1.0<!--correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps--></k>
+            </multi_slotted_flap_effect>
+          </CL>
+        </landing>
+      </high_lift_devices>
     </aerodynamics>
     <weight>
       <airframe>
         <flight_controls>
           <mass>
-            <k>1.0<!--flight controls (A4): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--flight controls (A4): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--flight controls (A4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--flight controls (A4): correction offset to be applied on computed mass--></offset>
           </mass>
         </flight_controls>
         <fuselage>
           <mass>
-            <k>1.1<!--fuselage (A2): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--fuselage (A2): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.1<!--fuselage (A2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--fuselage (A2): correction offset to be applied on computed mass--></offset>
           </mass>
         </fuselage>
         <horizontal_tail>
           <mass>
-            <k>1.08<!--horizontal tail (A31): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--horizontal tail (A31): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.08<!--horizontal tail (A31): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--horizontal tail (A31): correction offset to be applied on computed mass--></offset>
           </mass>
         </horizontal_tail>
         <landing_gear>
           <mass>
-            <k>0.85<!--landing gears (A5): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--landing gears (A5): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">0.85<!--landing gears (A5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--landing gears (A5): correction offset to be applied on computed mass--></offset>
           </mass>
         </landing_gear>
         <paint>
           <mass>
-            <k>1.0<!--paint (A7): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--paint (A7): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--paint (A7): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--paint (A7): correction offset to be applied on computed mass--></offset>
           </mass>
         </paint>
         <pylon>
           <mass>
-            <k>0.85<!--pylon (A6): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--pylon (A6): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">0.85<!--pylon (A6): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--pylon (A6): correction offset to be applied on computed mass--></offset>
           </mass>
         </pylon>
         <vertical_tail>
           <mass>
-            <k>1.0<!--vertical tail (A32): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--vertical tail (A32): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--vertical tail (A32): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--vertical tail (A32): correction offset to be applied on computed mass--></offset>
           </mass>
         </vertical_tail>
         <wing>
           <mass>
-            <k>1.05<!--wing (A1): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--wing (A1): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.05<!--wing (A1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--wing (A1): correction offset to be applied on computed mass--></offset>
           </mass>
           <bending_sizing>
             <mass>
-              <k>1.0<!--wing bending sizing (A11): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--wing bending sizing (A11): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--wing bending sizing (A11): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing bending sizing (A11): correction offset to be applied on computed mass--></offset>
             </mass>
           </bending_sizing>
           <reinforcements>
             <mass>
-              <k>1.0<!--wing reinforcements (A14): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--wing reinforcements (A14): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--wing reinforcements (A14): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing reinforcements (A14): correction offset to be applied on computed mass--></offset>
             </mass>
           </reinforcements>
           <ribs>
             <mass>
-              <k>1.0<!--wing ribs (A13): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--wing ribs (A13): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--wing ribs (A13): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing ribs (A13): correction offset to be applied on computed mass--></offset>
             </mass>
           </ribs>
           <secondary_parts>
             <mass>
-              <k>1.0<!--wing secondary parts (A15): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--wing secondary parts (A15): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--wing secondary parts (A15): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing secondary parts (A15): correction offset to be applied on computed mass--></offset>
             </mass>
           </secondary_parts>
           <shear_sizing>
             <mass>
-              <k>1.0<!--wing shear sizing (A12): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--wing shear sizing (A12): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--wing shear sizing (A12): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing shear sizing (A12): correction offset to be applied on computed mass--></offset>
             </mass>
           </shear_sizing>
         </wing>
       </airframe>
       <furniture>
-        <cargo_configuration>
-          <mass>
-            <k>1.0<!--cargo configuration (D1): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--cargo configuration (D1): correction offset to be applied on computed mass--></offset>
-          </mass>
-        </cargo_configuration>
         <food_water>
           <mass>
-            <k>1.0<!--food water (D3): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--food water (D3): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--food water (D3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--food water (D3): correction offset to be applied on computed mass--></offset>
           </mass>
         </food_water>
         <passenger_seats>
           <mass>
-            <k>1.0<!--passenger seats (D2): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--passenger seats (D2): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--passenger seats (D2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--passenger seats (D2): correction offset to be applied on computed mass--></offset>
           </mass>
         </passenger_seats>
         <security_kit>
           <mass>
-            <k>1.0<!--security kit (D4): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--security kit (D4): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--security kit (D4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--security kit (D4): correction offset to be applied on computed mass--></offset>
           </mass>
         </security_kit>
         <toilets>
           <mass>
-            <k>1.0<!--toilets (D5): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--toilets (D5): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--toilets (D5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--toilets (D5): correction offset to be applied on computed mass--></offset>
           </mass>
         </toilets>
       </furniture>
       <propulsion>
         <engine>
           <mass>
-            <k>1.0<!--engine (B1): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--engine (B1): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--engine (B1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--engine (B1): correction offset to be applied on computed mass--></offset>
           </mass>
         </engine>
         <fuel_lines>
           <mass>
-            <k>1.0<!--fuel lines (B2): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--fuel lines (B2): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--fuel lines (B2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--fuel lines (B2): correction offset to be applied on computed mass--></offset>
           </mass>
         </fuel_lines>
         <unconsumables>
           <mass>
-            <k>1.0<!--unconsumables (B3): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--unconsumables (B3): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--unconsumables (B3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--unconsumables (B3): correction offset to be applied on computed mass--></offset>
           </mass>
         </unconsumables>
       </propulsion>
       <systems>
         <flight_kit>
           <mass>
-            <k>1.0<!--flight kit (C6): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--flight kit (C6): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--flight kit (C6): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--flight kit (C6): correction offset to be applied on computed mass--></offset>
           </mass>
         </flight_kit>
         <navigation>
           <mass>
-            <k>1.0<!--navigation (C3): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--navigation (C3): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--navigation (C3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--navigation (C3): correction offset to be applied on computed mass--></offset>
           </mass>
         </navigation>
         <operational>
           <mass>
-            <k>1.0<!--operational (C5): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--operational (C5): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--operational (C5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--operational (C5): correction offset to be applied on computed mass--></offset>
           </mass>
         </operational>
         <transmission>
           <mass>
-            <k>1.0<!--transmission (C4): correction ratio to be applied on computed mass--></k>
-            <offset units="kg">0.0<!--transmission (C4): correction offset to be applied on computed mass--></offset>
+            <k is_input="True">1.0<!--transmission (C4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--transmission (C4): correction offset to be applied on computed mass--></offset>
           </mass>
         </transmission>
         <life_support>
           <air_conditioning>
             <mass>
-              <k>1.0<!--air conditioning (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--air conditioning (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--air conditioning (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--air conditioning (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </air_conditioning>
           <cabin_lighting>
             <mass>
-              <k>1.0<!--cabin lighting (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--cabin lighting (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--cabin lighting (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--cabin lighting (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </cabin_lighting>
           <de-icing>
             <mass>
-              <k>1.0<!--de-icing (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--de-icing (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--de-icing (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--de-icing (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </de-icing>
           <insulation>
             <mass>
-              <k>2.0<!--insulation (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--insulation (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">2.0<!--insulation (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--insulation (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </insulation>
           <oxygen>
             <mass>
-              <k>1.0<!--oxygen (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--oxygen (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--oxygen (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--oxygen (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </oxygen>
           <safety_equipment>
             <mass>
-              <k>1.0<!--safety equipment (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--safety equipment (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--safety equipment (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--safety equipment (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </safety_equipment>
           <seats_crew_accommodation>
             <mass>
-              <k>1.0<!--seats crew accommodation (C21): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--seats crew accommodation (C21): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--seats crew accommodation (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--seats crew accommodation (C21): correction offset to be applied on computed mass--></offset>
             </mass>
           </seats_crew_accommodation>
         </life_support>
         <power>
           <auxiliary_power_unit>
             <mass>
-              <k>1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
             </mass>
           </auxiliary_power_unit>
           <electric_systems>
             <mass>
-              <k>1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
             </mass>
           </electric_systems>
           <hydraulic_systems>
             <mass>
-              <k>1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
-              <offset units="kg">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+              <k is_input="True">1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
             </mass>
           </hydraulic_systems>
         </power>

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
@@ -24,7 +24,7 @@
     <geometry>
       <has_T_tail is_input="True">0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
       <aircraft>
-        <wetted_area units="m**2" is_input="False">801.4521728701311<!--total wetted area--></wetted_area>
+        <wetted_area units="m**2" is_input="False">801.4521728689252<!--total wetted area--></wetted_area>
       </aircraft>
       <cabin>
         <NPAX1 is_input="False">157.0<!--number of passengers if there are only economical class seats--></NPAX1>
@@ -60,35 +60,35 @@
         <wetted_area units="m**2" is_input="False">401.95600094323777<!--wetted area of fuselage--></wetted_area>
       </fuselage>
       <horizontal_tail>
-        <area units="m**2" is_input="False">35.50596767649052<!--horizontal tail area--></area>
+        <area units="m**2" is_input="False">35.50596767640397<!--horizontal tail area--></area>
         <aspect_ratio is_input="True">4.28778048454<!--aspect ratio of horizontal tail--></aspect_ratio>
-        <span units="m" is_input="False">12.338630199159361<!--horizontal tail span--></span>
+        <span units="m" is_input="False">12.338630199125644<!--horizontal tail span--></span>
         <sweep_0 units="deg" is_input="False">33.31651496553977<!--sweep angle at leading edge of horizontal tail--></sweep_0>
-        <sweep_100 units="deg" is_input="False">8.80894178425667<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
+        <sweep_100 units="deg" is_input="False">8.808941784256671<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
         <sweep_25 units="deg" is_input="True">28.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
         <taper_ratio is_input="True">0.3<!--taper ratio of horizontal tail--></taper_ratio>
         <thickness_ratio is_input="True">0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
-        <wetted_area units="m**2" is_input="False">71.01193535298104<!--wetted area of horizontal tail--></wetted_area>
+        <wetted_area units="m**2" is_input="False">71.01193535280794<!--wetted area of horizontal tail--></wetted_area>
         <MAC>
-          <length units="m" is_input="False">3.1557401632488755<!--_inp_data:geometry:horizontal_tail:MAC:length--></length>
-          <y units="m" is_input="False">2.531001066494228<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
+          <length units="m" is_input="False">3.1557401632402526<!--_inp_data:geometry:horizontal_tail:MAC:length--></length>
+          <y units="m" is_input="False">2.5310010664873115<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
           <at25percent>
-            <x units="m" is_input="False">34.131701240000005<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x--><from_wingMAC25 units="m" is_input="False">17.524905240000006<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">2.452536512401557<!--X-position of the 25% of mean aerodynamic chord of horizontal tail w.r.t. leading edge of root chord--></local></x>
+            <x units="m" is_input="False">34.131701240000005<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x--><from_wingMAC25 units="m" is_input="False">17.524905240000006<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">2.452536512394855<!--X-position of the 25% of mean aerodynamic chord of horizontal tail w.r.t. leading edge of root chord--></local></x>
           </at25percent>
           <leading_edge>
-            <x units="m" is_input="False">33.342766199187786<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x--><local units="m" is_input="False">1.6636014715893381<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">33.342766199189946<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x--><local units="m" is_input="False">1.6636014715847915<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x:local--></local></x>
           </leading_edge>
         </MAC>
         <center>
-          <chord units="m" is_input="False">4.427117495205257<!--chord length at center of horizontal tail--></chord>
+          <chord units="m" is_input="False">4.427117495193159<!--chord length at center of horizontal tail--></chord>
           <leading_edge>
-            <x units="m" is_input="False">31.679164727598447<!--_inp_data:geometry:horizontal_tail:center:leading_edge:x--><local units="m" is_input="False">2.220446049250313e-16<!--X-position of the leading edge at center of horizontal tail w.r.t. leading edge of center chord--></local></x>
+            <x units="m" is_input="False">31.679164727605155<!--_inp_data:geometry:horizontal_tail:center:leading_edge:x--><local units="m" is_input="False">-2.220446049250313e-16<!--X-position of the leading edge at center of horizontal tail w.r.t. leading edge of center chord--></local></x>
           </leading_edge>
         </center>
         <tip>
-          <chord units="m" is_input="False">1.3281352485615772<!--chord length at tip of horizontal tail--></chord>
+          <chord units="m" is_input="False">1.3281352485579478<!--chord length at tip of horizontal tail--></chord>
           <leading_edge>
-            <x units="m" is_input="False">35.73419331459746<!--X-position of leading edge at horizontal tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">4.055028586999011<!--_inp_data:geometry:horizontal_tail:tip:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">35.734193314593085<!--X-position of leading edge at horizontal tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">4.05502858698793<!--_inp_data:geometry:horizontal_tail:tip:leading_edge:x:local--></local></x>
           </leading_edge>
         </tip>
       </horizontal_tail>
@@ -108,7 +108,7 @@
           <diameter units="m" is_input="False">2.1722438645822235<!--nacelle diameter--></diameter>
           <length units="m" is_input="False">5.2114827064857465<!--nacelle length--></length>
           <wetted_area units="m**2" is_input="False">21.6092<!--wetted area of nacelle--></wetted_area>
-          <y units="m" is_input="False">5.975275465106045<!--Y-position of nacelle center--></y>
+          <y units="m" is_input="False">5.975275465099392<!--Y-position of nacelle center--></y>
         </nacelle>
         <pylon>
           <length units="m" is_input="False">5.732630977134321<!--pylon length--></length>
@@ -120,87 +120,87 @@
         <span_ratio is_input="True">0.9<!--ratio (width of slats)/(total span)--></span_ratio>
       </slat>
       <vertical_tail>
-        <area units="m**2" is_input="False">27.68760484856992<!--vertical tail area--></area>
+        <area units="m**2" is_input="False">27.687604848506492<!--vertical tail area--></area>
         <aspect_ratio is_input="True">1.74462618632<!--aspect ratio of vertical tail--></aspect_ratio>
-        <span units="m" is_input="False">6.950145352909223<!--vertical tail span--></span>
+        <span units="m" is_input="False">6.950145352891376<!--vertical tail span--></span>
         <sweep_0 units="deg" is_input="False">40.51480176597914<!--sweep angle at leading edge of vertical tail--></sweep_0>
         <sweep_100 units="deg" is_input="False">13.34651978540079<!--sweep angle at trailing edge of vertical tail--></sweep_100>
         <sweep_25 units="deg" is_input="True">35.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
         <taper_ratio is_input="True">0.3<!--taper ratio of vertical tail--></taper_ratio>
         <thickness_ratio is_input="True">0.1<!--thickness ratio of vertical tail--></thickness_ratio>
-        <wetted_area units="m**2" is_input="False">58.14397018199684<!--wetted area of vertical tail--></wetted_area>
+        <wetted_area units="m**2" is_input="False">58.14397018186364<!--wetted area of vertical tail--></wetted_area>
         <MAC>
-          <length units="m" is_input="False">4.368761464807569<!--_inp_data:geometry:vertical_tail:MAC:length--></length>
-          <z units="m" is_input="False">2.8513416832448093<!--Z-position of mean aerodynamic chord of vertical tail--></z>
+          <length units="m" is_input="False">4.368761464796353<!--_inp_data:geometry:vertical_tail:MAC:length--></length>
+          <z units="m" is_input="False">2.8513416832374876<!--Z-position of mean aerodynamic chord of vertical tail--></z>
           <at25percent>
-            <x units="m" is_input="False">33.00648032<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. nose of aircraft--><from_wingMAC25 units="m" is_input="False">16.399684320000002<!--_inp_data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">3.528740447161801<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. leading edge of root chord--></local></x>
+            <x units="m" is_input="False">33.00648032<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. nose of aircraft--><from_wingMAC25 units="m" is_input="False">16.399684320000002<!--_inp_data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">3.52874044715274<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. leading edge of root chord--></local></x>
           </at25percent>
           <leading_edge>
-            <x units="m" is_input="False">31.91428995379811<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">2.4365500809599085<!--_inp_data:geometry:vertical_tail:MAC:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">31.914289953800914<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">2.436550080953652<!--_inp_data:geometry:vertical_tail:MAC:leading_edge:x:local--></local></x>
           </leading_edge>
         </MAC>
         <root>
-          <chord units="m" is_input="False">6.128838026168894<!--chord length at root of vertical tail--></chord>
+          <chord units="m" is_input="False">6.128838026153156<!--chord length at root of vertical tail--></chord>
           <leading_edge>
-            <x units="m" is_input="False">29.4777398728382<local units="m" is_input="False">4.440892098500626e-16<!--X-position of leading edge at vertical tail tip w.r.t. leading edge of root chord--></local></x>
+            <x units="m" is_input="False">29.477739872847263<local units="m" is_input="False">4.440892098500626e-16<!--X-position of leading edge at vertical tail tip w.r.t. leading edge of root chord--></local></x>
           </leading_edge>
         </root>
         <tip>
-          <chord units="m" is_input="False">1.838651407850668<!--chord length at tip of vertical tail--></chord>
+          <chord units="m" is_input="False">1.8386514078459468<!--chord length at tip of vertical tail--></chord>
           <leading_edge>
-            <x units="m" is_input="False">35.41683069517797<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">5.939090822339777<!--_inp_data:geometry:vertical_tail:tip:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">35.41683069517178<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">5.939090822324525<!--_inp_data:geometry:vertical_tail:tip:leading_edge:x:local--></local></x>
           </leading_edge>
         </tip>
       </vertical_tail>
       <wing>
-        <area units="m**2" is_input="False">130.31958336291922<!--wing reference area--></area>
+        <area units="m**2" is_input="False">130.31958336278984<!--wing reference area--></area>
         <aspect_ratio is_input="True">9.48<!--wing aspect ratio--></aspect_ratio>
-        <b_50 units="m" is_input="False">38.14207005665248<!--actual length between root and tip along 50% of chord--></b_50>
-        <outer_area units="m**2" is_input="False">105.99771323572124<!--wing area outside of fuselage--></outer_area>
-        <span units="m" is_input="False">35.148679206506145<!--wing span--></span>
-        <sweep_0 units="deg" is_input="False">27.07669256968531<!--sweep angle at leading edge of wing--></sweep_0>
+        <b_50 units="m" is_input="False">38.14207005660993<!--actual length between root and tip along 50% of chord--></b_50>
+        <outer_area units="m**2" is_input="False">105.9977132354617<!--wing area outside of fuselage--></outer_area>
+        <span units="m" is_input="False">35.14867920646701<!--wing span--></span>
+        <sweep_0 units="deg" is_input="False">27.07669256968555<!--sweep angle at leading edge of wing--></sweep_0>
         <sweep_100_inner units="deg" is_input="False">0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
-        <sweep_100_outer units="deg" is_input="False">18.345144006915444<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
+        <sweep_100_outer units="deg" is_input="False">18.34514400691462<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
         <sweep_100_ratio is_input="True">0.0<!--ratio inner/outer for sweep angles at trailing edge of wing--></sweep_100_ratio>
         <sweep_25 units="deg" is_input="True">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio is_input="False">0.2770432482365717<!--taper ratio of wing--></taper_ratio>
+        <taper_ratio is_input="False">0.27704324823660603<!--taper ratio of wing--></taper_ratio>
         <thickness_ratio is_input="False">0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
         <virtual_taper_ratio is_input="True">0.38<!--taper ratio of wing computed from virtual root chord--></virtual_taper_ratio>
-        <wetted_area units="m**2" is_input="False">211.99542647144247<!--wetted area of wing--></wetted_area>
+        <wetted_area units="m**2" is_input="False">211.9954264709234<!--wetted area of wing--></wetted_area>
         <MAC>
-          <length units="m" is_input="False">4.275012578259086<!--_inp_data:geometry:wing:MAC:length--></length>
-          <y units="m" is_input="False">6.852580888040769<!--Y-position of mean aerodynamic chord of wing--></y>
+          <length units="m" is_input="False">4.275012578254216<!--_inp_data:geometry:wing:MAC:length--></length>
+          <y units="m" is_input="False">6.8525808880332955<!--Y-position of mean aerodynamic chord of wing--></y>
           <at25percent>
             <x units="m" is_input="True">16.606796<!--_inp_data:geometry:wing:MAC:at25percent:x--></x>
           </at25percent>
           <leading_edge>
-            <x units="m" is_input="False">15.538042855435227<local units="m" is_input="False">2.59467774572138<!--_inp_data:geometry:wing:MAC:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">15.538042855436444<local units="m" is_input="False">2.5946777457176764<!--_inp_data:geometry:wing:MAC:leading_edge:x:local--></local></x>
           </leading_edge>
         </MAC>
         <kink>
-          <chord units="m" is_input="False">3.613004896259709<!--chord length at wing kink--></chord>
+          <chord units="m" is_input="False">3.613004896255873<!--chord length at wing kink--></chord>
           <span_ratio is_input="True">0.4<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
           <thickness_ratio is_input="False">0.12069450428120491<!--thickness ratio at wing kink--></thickness_ratio>
-          <y units="m" is_input="False">7.029735841301229<!--Y-position of wing kink--></y>
+          <y units="m" is_input="False">7.029735841293402<!--Y-position of wing kink--></y>
           <leading_edge>
-            <x units="m" is_input="False">15.535108852083562<local units="m" is_input="False">2.5917437423697143<!--_inp_data:geometry:wing:kink:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">15.535108852084509<local units="m" is_input="False">2.5917437423657397<!--_inp_data:geometry:wing:kink:leading_edge:x:local--></local></x>
           </leading_edge>
         </kink>
         <root>
-          <chord units="m" is_input="False">6.2047486386294235<!--chord length at wing root--></chord>
+          <chord units="m" is_input="False">6.204748638621613<!--chord length at wing root--></chord>
           <thickness_ratio is_input="False">0.15921402692414266<!--thickness ratio at wing root--></thickness_ratio>
-          <virtual_chord units="m" is_input="False">4.523641361414057<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
+          <virtual_chord units="m" is_input="False">4.523641361408923<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
           <y units="m" is_input="False">1.95994<!--Y-position of wing root--></y>
           <leading_edge>
-            <x units="m" is_input="False">12.943365109713847</x>
+            <x units="m" is_input="False">12.94336510971877</x>
           </leading_edge>
         </root>
         <tip>
-          <chord units="m" is_input="False">1.718983717337342<!--chord length at wing tip--></chord>
+          <chord units="m" is_input="False">1.7189837173353908<!--chord length at wing tip--></chord>
           <thickness_ratio is_input="False">0.11042263157642153<!--thickness ratio at wing tip--></thickness_ratio>
-          <y units="m" is_input="False">17.574339603253073<!--Y-position of wing tip--></y>
+          <y units="m" is_input="False">17.574339603233504<!--Y-position of wing tip--></y>
           <leading_edge>
-            <x units="m" is_input="False">20.925643633222307<local units="m" is_input="False">7.98227852350846<!--_inp_data:geometry:wing:tip:leading_edge:x:local--></local></x>
+            <x units="m" is_input="False">20.92564363321731<local units="m" is_input="False">7.982278523498538<!--_inp_data:geometry:wing:tip:leading_edge:x:local--></local></x>
           </leading_edge>
         </tip>
         <spar_ratio>
@@ -218,7 +218,7 @@
       </wing>
     </geometry>
     <handling_qualities>
-      <static_margin is_input="False">0.012648162052125211<!--(X-position of neutral point - X-position of center of gravity ) / (mean aerodynamic chord)--></static_margin>
+      <static_margin is_input="False">0.012648162052126988<!--(X-position of neutral point - X-position of center of gravity ) / (mean aerodynamic chord)--></static_margin>
     </handling_qualities>
     <load_case>
       <gust_intensity is_input="True">0.5<!--a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated--></gust_intensity>
@@ -249,25 +249,25 @@
     <mission>
       <sizing>
         <ISA_offset units="degK" is_input="True">0.0<!--Input defined by the mission.--></ISA_offset>
-        <TOW units="kg" is_input="False">77086.92304606961<!--Loaded fuel at beginning for mission "sizing"--></TOW>
-        <ZFW units="kg" is_input="False">56583.56078276247<!--Zero Fuel Weight for mission "sizing"--></ZFW>
-        <block_fuel units="kg" is_input="False">20503.36227063105<!--Loaded fuel at beginning for mission "sizing"_inp_data:mission:sizing:block_fuel--></block_fuel>
+        <TOW units="kg" is_input="False">77086.92304594585<!--Loaded fuel at beginning for mission "sizing"--></TOW>
+        <ZFW units="kg" is_input="False">56583.560782701934<!--Zero Fuel Weight for mission "sizing"--></ZFW>
+        <block_fuel units="kg" is_input="False">20503.362270602855<!--Loaded fuel at beginning for mission "sizing"_inp_data:mission:sizing:block_fuel--></block_fuel>
         <consumed_fuel_before_input_weight units="kg" is_input="False">0.0<!--consumed fuel quantity before target mass defined for "sizing", if any (e.g. TakeOff Weight)--></consumed_fuel_before_input_weight>
         <distance units="m" is_input="False">5093000.0<!--covered ground distance during mission "sizing"--></distance>
         <duration units="s" is_input="False">19857.45794460585<!--duration of mission "sizing"--></duration>
-        <fuel units="kg" is_input="False">20503.36227063105<!--burned fuel during mission "sizing"--></fuel>
-        <needed_block_fuel units="kg" is_input="False">20503.36227063105<!--Needed fuel to complete mission "sizing", including reserve fuel--></needed_block_fuel>
-        <specific_burned_fuel units="1/nmi" is_input="False">0.0005478959507944804</specific_burned_fuel>
+        <fuel units="kg" is_input="False">20503.362270602855<!--burned fuel during mission "sizing"--></fuel>
+        <needed_block_fuel units="kg" is_input="False">20503.362270602855<!--Needed fuel to complete mission "sizing", including reserve fuel--></needed_block_fuel>
+        <specific_burned_fuel units="1/nmi" is_input="False">0.000547895950793727</specific_burned_fuel>
         <cs25>
           <load_factor_1 is_input="False">3.75</load_factor_1>
           <load_factor_2 is_input="False">3.75</load_factor_2>
-          <sizing_load_1 units="kg" is_input="False">246422.7705202372</sizing_load_1>
-          <sizing_load_2 units="kg" is_input="False">259162.7766680397</sizing_load_2>
+          <sizing_load_1 units="kg" is_input="False">246422.77051970272</sizing_load_1>
+          <sizing_load_2 units="kg" is_input="False">259162.77666729141</sizing_load_2>
         </cs25>
         <global_reserve>
           <distance units="m" is_input="False">0.0<!--covered ground distance during route "global_reserve" in mission "sizing"--></distance>
           <duration units="s" is_input="False">0.0<!--duration of route "global_reserve" in mission "sizing"--></duration>
-          <fuel units="kg" is_input="False">3395.0136465263204<!--burned fuel during route "global_reserve" in mission "sizing"--></fuel>
+          <fuel units="kg" is_input="False">3395.013646520587<!--burned fuel during route "global_reserve" in mission "sizing"--></fuel>
         </global_reserve>
         <landing>
           <flap_angle units="deg" is_input="True">30.0</flap_angle>
@@ -276,22 +276,22 @@
         <main_route>
           <distance units="m" is_input="False">5093000.0<!--covered ground distance during route "main_route" in mission "sizing"--></distance>
           <duration units="s" is_input="False">19857.45794460585<!--duration of route "main_route" in mission "sizing"--></duration>
-          <fuel units="kg" is_input="False">17108.34862410473<!--burned fuel during route "main_route" in mission "sizing"--></fuel>
+          <fuel units="kg" is_input="False">17108.348624082268<!--burned fuel during route "main_route" in mission "sizing"--></fuel>
           <climb>
             <distance units="m" is_input="False">250000.0<!--covered ground distance during phase "climb" of route "main_route" in mission "sizing"--></distance>
             <duration units="s" is_input="False">0.0<!--duration of phase "climb" of route "main_route" in mission "sizing"--></duration>
-            <fuel units="kg" is_input="False">2312.607691382087<!--burned fuel during phase "climb" of route "main_route" in mission "sizing"--></fuel>
+            <fuel units="kg" is_input="False">2312.6076913783763<!--burned fuel during phase "climb" of route "main_route" in mission "sizing"--></fuel>
           </climb>
           <cruise>
             <altitude units="ft" is_input="True">35000.0<!--Input defined by the mission.--></altitude>
             <distance units="m" is_input="False">4593000.0<!--covered ground distance during phase "cruise" of route "main_route" in mission "sizing"--></distance>
             <duration units="s" is_input="False">19857.45794460585<!--duration of phase "cruise" of route "main_route" in mission "sizing"--></duration>
-            <fuel units="kg" is_input="False">13571.688393498865<!--burned fuel during phase "cruise" of route "main_route" in mission "sizing"--></fuel>
+            <fuel units="kg" is_input="False">13571.688393482182<!--burned fuel during phase "cruise" of route "main_route" in mission "sizing"--></fuel>
           </cruise>
           <descent>
             <distance units="m" is_input="False">250000.0<!--covered ground distance during phase "descent" of route "main_route" in mission "sizing"--></distance>
             <duration units="s" is_input="False">0.0<!--duration of phase "descent" of route "main_route" in mission "sizing"--></duration>
-            <fuel units="kg" is_input="False">1224.052539223776<!--burned fuel during phase "descent" of route "main_route" in mission "sizing"--></fuel>
+            <fuel units="kg" is_input="False">1224.0525392217096<!--burned fuel during phase "descent" of route "main_route" in mission "sizing"--></fuel>
           </descent>
         </main_route>
         <start>
@@ -319,61 +319,61 @@
     </mission>
     <weight>
       <aircraft>
-        <MFW units="kg" is_input="False">20503.362263307135<!--maximum fuel weight--></MFW>
-        <MLW units="kg" is_input="False">66338.57442972822<!--maximum landing weight--></MLW>
-        <MTOW units="kg" is_input="False">77086.92304606961<!--maximum takeoff weight--></MTOW>
-        <MZFW units="kg" is_input="False">62583.56078276247<!--maximum zero fuel weight--></MZFW>
-        <OWE units="kg" is_input="False">42975.56078276247<!--Mass of crew--></OWE>
-        <additional_fuel_capacity units="kg" is_input="False">-7.323913450818509e-06<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
+        <MFW units="kg" is_input="False">20503.3622632439<!--maximum fuel weight--></MFW>
+        <MLW units="kg" is_input="False">66338.57442966405<!--maximum landing weight--></MLW>
+        <MTOW units="kg" is_input="False">77086.92304594585<!--maximum takeoff weight--></MTOW>
+        <MZFW units="kg" is_input="False">62583.560782701934<!--maximum zero fuel weight--></MZFW>
+        <OWE units="kg" is_input="False">42975.560782701934<!--Mass of crew--></OWE>
+        <additional_fuel_capacity units="kg" is_input="False">-7.358954462688416e-06<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
         <max_payload units="kg" is_input="False">19608.0<!--max payload weight--></max_payload>
         <payload units="kg" is_input="False">13608.0<!--_inp_data:weight:aircraft:payload--></payload>
-        <sizing_block_fuel units="kg" is_input="False">20503.36227063105<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>
-        <sizing_onboard_fuel_at_input_weight units="kg" is_input="False">20503.36227063105<!--_inp_data:weight:aircraft:sizing_onboard_fuel_at_input_weight--></sizing_onboard_fuel_at_input_weight>
+        <sizing_block_fuel units="kg" is_input="False">20503.362270602855<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>
+        <sizing_onboard_fuel_at_input_weight units="kg" is_input="False">20503.362270602855<!--_inp_data:weight:aircraft:sizing_onboard_fuel_at_input_weight--></sizing_onboard_fuel_at_input_weight>
         <CG>
           <aft>
-            <MAC_position is_input="False">0.40811448585698545<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
-            <x units="m" is_input="False">17.28273741584358<!--most aft X-position of aircraft center of gravity--></x>
+            <MAC_position is_input="False">0.40811448585587035<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
+            <x units="m" is_input="False">17.282737415838042<!--most aft X-position of aircraft center of gravity--></x>
           </aft>
         </CG>
         <empty>
           <CG>
-            <MAC_position is_input="False">0.35757498027841933<!--X-position of center of gravity as ratio of mean aerodynamic chord for empty aircraft--></MAC_position>
+            <MAC_position is_input="False">0.35757498027673024<!--X-position of center of gravity as ratio of mean aerodynamic chord for empty aircraft--></MAC_position>
           </CG>
         </empty>
         <load_cases>
           <CG>
-            <MAC_position is_input="False">[[0.3344061576349848], [0.25616793370146423], [0.35582894571419793], [0.35811448585698546]]<maximum is_input="False">0.35811448585698546</maximum></MAC_position>
+            <MAC_position is_input="False">[[0.3344061576336108], [0.25616793370051805], [0.3558289457129706], [0.35811448585587036]]<maximum is_input="False">0.35811448585587036</maximum></MAC_position>
           </CG>
         </load_cases>
       </aircraft>
       <aircraft_empty>
-        <mass units="kg" is_input="False">42505.56076704436<!--mass of empty aircraft (=OWE - mass of crew)--></mass>
+        <mass units="kg" is_input="False">42505.56076690862<!--mass of empty aircraft (=OWE - mass of crew)--></mass>
         <CG>
-          <x units="m" is_input="False">17.066680393796215<!--X-position center of gravity of empty aircraft--></x>
+          <x units="m" is_input="False">17.06668039378847<!--X-position center of gravity of empty aircraft--></x>
         </CG>
       </aircraft_empty>
       <airframe>
-        <mass units="kg" is_input="False">23755.04955102467<!--Mass of airframe--></mass>
+        <mass units="kg" is_input="False">23755.049550968724<!--Mass of airframe--></mass>
         <flight_controls>
-          <mass units="kg" is_input="False">769.5997397224129<!--Mass of airframe_inp_data:weight:airframe:flight_controls:mass--></mass>
+          <mass units="kg" is_input="False">769.5997397199061<!--Mass of airframe_inp_data:weight:airframe:flight_controls:mass--></mass>
           <CG>
-            <x units="m" is_input="False">19.14811374834327<!--flight controls (A4): X-position of center of gravity--></x>
+            <x units="m" is_input="False">19.14811374834038<!--flight controls (A4): X-position of center of gravity--></x>
           </CG>
         </flight_controls>
         <fuselage>
-          <mass units="kg" is_input="False">8872.865285701002<!--Mass of airframe_inp_data:weight:airframe:fuselage:mass--></mass>
+          <mass units="kg" is_input="False">8872.86528569665<!--Mass of airframe_inp_data:weight:airframe:fuselage:mass--></mass>
           <CG>
             <x units="m" is_input="False">16.8783138<!--fuselage (A2): X-position of center of gravity--></x>
           </CG>
         </fuselage>
         <horizontal_tail>
-          <mass units="kg" is_input="False">763.2255928719553<!--Mass of airframe_inp_data:weight:airframe:horizontal_tail:mass--></mass>
+          <mass units="kg" is_input="False">763.2255928666307<!--Mass of airframe_inp_data:weight:airframe:horizontal_tail:mass--></mass>
           <CG>
-            <x units="m" is_input="False">33.79593233126773<!--horizontal tail (A31): X-position of center of gravity--></x>
+            <x units="m" is_input="False">33.79593233126865<!--horizontal tail (A31): X-position of center of gravity--></x>
           </CG>
         </horizontal_tail>
         <paint>
-          <mass units="kg" is_input="False">144.2613911166236<!--Mass of airframe_inp_data:weight:airframe:paint:mass--></mass>
+          <mass units="kg" is_input="False">144.26139111640654<!--Mass of airframe_inp_data:weight:airframe:paint:mass--></mass>
           <CG>
             <x units="m" is_input="False">0.0<!--paint (A7): X-position of center of gravity--></x>
           </CG>
@@ -381,32 +381,32 @@
         <pylon>
           <mass units="kg" is_input="False">1211.8837953053956<!--Mass of airframe_inp_data:weight:airframe:pylon:mass--></mass>
           <CG>
-            <x units="m" is_input="False">13.746155913953858<!--pylon (A6): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.74615591395562<!--pylon (A6): X-position of center of gravity--></x>
           </CG>
         </pylon>
         <vertical_tail>
-          <mass units="kg" is_input="False">582.627393846386<!--Mass of airframe_inp_data:weight:airframe:vertical_tail:mass--></mass>
+          <mass units="kg" is_input="False">582.6273938425985<!--Mass of airframe_inp_data:weight:airframe:vertical_tail:mass--></mass>
           <CG>
-            <x units="m" is_input="False">33.23512832108261<!--vertical tail (A32): X-position of center of gravity--></x>
+            <x units="m" is_input="False">33.23512832108202<!--vertical tail (A32): X-position of center of gravity--></x>
           </CG>
         </vertical_tail>
         <wing>
-          <mass units="kg" is_input="False">8845.195629323802<!--Mass of airframe_inp_data:weight:airframe:wing:mass--></mass>
+          <mass units="kg" is_input="False">8845.195629293266<!--Mass of airframe_inp_data:weight:airframe:wing:mass--></mass>
           <CG>
-            <x units="m" is_input="False">16.710435497577926<!--wing (A1): X-position of center of gravity--></x>
+            <x units="m" is_input="False">16.710435497577805<!--wing (A1): X-position of center of gravity--></x>
           </CG>
         </wing>
         <landing_gear>
           <front>
-            <mass units="kg" is_input="False">384.2208302629416<!--Mass of airframe_inp_data:weight:airframe:landing_gear:front:mass--></mass>
+            <mass units="kg" is_input="False">384.22083026177916<!--Mass of airframe_inp_data:weight:airframe:landing_gear:front:mass--></mass>
             <CG>
               <x units="m" is_input="False">5.176347<!--front landing gear (A52): X-position of center of gravity--></x>
             </CG>
           </front>
           <main>
-            <mass units="kg" is_input="False">2181.16989287415<!--Mass of airframe_inp_data:weight:airframe:landing_gear:main:mass--></mass>
+            <mass units="kg" is_input="False">2181.1698928660862<!--Mass of airframe_inp_data:weight:airframe:landing_gear:main:mass--></mass>
             <CG>
-              <x units="m" is_input="False">18.335467017221283<!--main landing gear (A51): X-position of center of gravity--></x>
+              <x units="m" is_input="False">18.33546701721526<!--main landing gear (A51): X-position of center of gravity--></x>
             </CG>
           </main>
         </landing_gear>
@@ -442,28 +442,28 @@
         </toilets>
       </furniture>
       <propulsion>
-        <mass units="kg" is_input="False">7748.006297727328<!--Mass of the propulsion system--></mass>
+        <mass units="kg" is_input="False">7748.006297726523<!--Mass of the propulsion system--></mass>
         <engine>
           <mass units="kg" is_input="False">7161.3348000000005<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
           <CG>
-            <x units="m" is_input="False">13.746155913953858<!--engine (B1): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.74615591395562<!--engine (B1): X-position of center of gravity--></x>
           </CG>
         </engine>
         <fuel_lines>
-          <mass units="kg" is_input="False">464.9097298057535<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
+          <mass units="kg" is_input="False">464.90972980516887<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
           <CG>
-            <x units="m" is_input="False">13.746155913953858<!--fuel lines (B2): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.74615591395562<!--fuel lines (B2): X-position of center of gravity--></x>
           </CG>
         </fuel_lines>
         <unconsumables>
-          <mass units="kg" is_input="False">121.76176792157497<!--Mass of the propulsion system_inp_data:weight:propulsion:unconsumables:mass--></mass>
+          <mass units="kg" is_input="False">121.76176792135365<!--Mass of the propulsion system_inp_data:weight:propulsion:unconsumables:mass--></mass>
           <CG>
-            <x units="m" is_input="False">13.746155913953858<!--unconsumables (B3): X-position of center of gravity--></x>
+            <x units="m" is_input="False">13.74615591395562<!--unconsumables (B3): X-position of center of gravity--></x>
           </CG>
         </unconsumables>
       </propulsion>
       <systems>
-        <mass units="kg" is_input="False">7890.004934010472<!--Mass of aircraft systems--></mass>
+        <mass units="kg" is_input="False">7890.004934006684<!--Mass of aircraft systems--></mass>
         <flight_kit>
           <mass units="kg" is_input="False">45.0<!--Mass of aircraft systems_inp_data:weight:systems:flight_kit:mass--></mass>
           <CG>
@@ -471,7 +471,7 @@
           </CG>
         </flight_kit>
         <navigation>
-          <mass units="kg" is_input="False">497.210080675836<!--Mass of aircraft systems_inp_data:weight:systems:navigation:mass--></mass>
+          <mass units="kg" is_input="False">497.2100806757834<!--Mass of aircraft systems_inp_data:weight:systems:navigation:mass--></mass>
           <CG>
             <x units="m" is_input="False">5.5214368<!--navigation (C3): X-position of center of gravity--></x>
           </CG>
@@ -496,9 +496,9 @@
             </CG>
           </cabin_lighting>
           <de-icing>
-            <mass units="kg" is_input="False">160.91105315271096<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de-icing:mass--></mass>
+            <mass units="kg" is_input="False">160.9110531526276<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de-icing:mass--></mass>
             <CG>
-              <x units="m" is_input="False">15.965544113261137<!--de-icing (C2): X-position of center of gravity--></x>
+              <x units="m" is_input="False">15.965544113261867<!--de-icing (C2): X-position of center of gravity--></x>
             </CG>
           </de-icing>
           <insulation>
@@ -516,7 +516,7 @@
           <safety_equipment>
             <mass units="kg" is_input="False">432.713348<!--Mass of aircraft systems_inp_data:weight:systems:life_support:safety_equipment:mass--></mass>
             <CG>
-              <x units="m" is_input="False">16.14170978318939<!--safety equipment (C21): X-position of center of gravity--></x>
+              <x units="m" is_input="False">16.141709783189683<!--safety equipment (C21): X-position of center of gravity--></x>
             </CG>
           </safety_equipment>
           <seats_crew_accommodation>
@@ -528,7 +528,7 @@
         </life_support>
         <operational>
           <cargo_hold>
-            <mass units="kg" is_input="False">278.23070548485737<!--Mass of aircraft systems_inp_data:weight:systems:operational:cargo_hold:mass--></mass>
+            <mass units="kg" is_input="False">278.2307054850035<!--Mass of aircraft systems_inp_data:weight:systems:operational:cargo_hold:mass--></mass>
             <CG>
               <x units="m" is_input="False">16.616796<!--cargo hold (C52): X-position of center of gravity--></x>
             </CG>
@@ -548,13 +548,13 @@
             </CG>
           </auxiliary_power_unit>
           <electric_systems>
-            <mass units="kg" is_input="False">1340.3466505852334<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
+            <mass units="kg" is_input="False">1340.346650582824<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
             <CG>
               <x units="m" is_input="False">18.753682<!--power (C1): X-position of center of gravity--></x>
             </CG>
           </electric_systems>
           <hydraulic_systems>
-            <mass units="kg" is_input="False">771.758609463683<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
+            <mass units="kg" is_input="False">771.7586094622948<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
             <CG>
               <x units="m" is_input="False">18.753682<!--power (C1): X-position of center of gravity--></x>
             </CG>
@@ -563,7 +563,7 @@
       </systems>
       <fuel_tank>
         <CG>
-          <x units="m" is_input="False">16.1130986828687<!--fuel tank: X-position of center of gravity--></x>
+          <x units="m" is_input="False">16.113098682869346<!--fuel tank: X-position of center of gravity--></x>
         </CG>
       </fuel_tank>
       <payload>
@@ -574,12 +574,12 @@
         </PAX>
         <front_fret>
           <CG>
-            <x units="m" is_input="False">9.922580554856923<!--front fret: X-position of center of gravity--></x>
+            <x units="m" is_input="False">9.922580554859383<!--front fret: X-position of center of gravity--></x>
           </CG>
         </front_fret>
         <rear_fret>
           <CG>
-            <x units="m" is_input="False">20.829480010308693<!--rear fret: X-position of center of gravity--></x>
+            <x units="m" is_input="False">20.829480010308032<!--rear fret: X-position of center of gravity--></x>
           </CG>
         </rear_fret>
       </payload>
@@ -587,73 +587,73 @@
     <aerodynamics>
       <aircraft>
         <cruise>
-          <AoA units="rad" is_input="False">[-0.015581773843222275, -0.014023596458900047, -0.01246541907457782, -0.010907241690255592, -0.009349064305933364, -0.007790886921611138, -0.006232709537288911, -0.004674532152966682, -0.0031163547686444554, -0.0015581773843222288, 0.0, 0.0015581773843222266, 0.003116354768644453, 0.004674532152966682, 0.006232709537288911, 0.007790886921611135, 0.009349064305933364, 0.010907241690255592, 0.012465419074577818, 0.014023596458900046, 0.015581773843222275, 0.017139951227544498, 0.01869812861186673, 0.020256305996188956, 0.02181448338051118, 0.02337266076483341, 0.02493083814915564, 0.026489015533477867, 0.028047192917800095, 0.029605370302122316, 0.031163547686444547, 0.032721725070766775, 0.034279902455089, 0.03583807983941123, 0.03739625722373346, 0.038954434608055685, 0.04051261199237791, 0.04207078937670014, 0.04362896676102237, 0.0451871441453446, 0.04674532152966683, 0.04830349891398906, 0.04986167629831127, 0.0514198536826335, 0.05297803106695573, 0.054536208451277955, 0.05609438583560018, 0.05765256321992241, 0.05921074060424464, 0.06076891798856687, 0.0623270953728891, 0.06388527275721133, 0.06544345014153356, 0.06700162752585578, 0.06855980491017802, 0.07011798229450024, 0.07167615967882247, 0.0732343370631447, 0.07479251444746692, 0.07635069183178914, 0.07790886921611137, 0.07946704660043359, 0.08102522398475583, 0.08258340136907806, 0.08414157875340028, 0.08569975613772252, 0.08725793352204474, 0.08881611090636697, 0.0903742882906892, 0.09193246567501143, 0.09349064305933366, 0.09504882044365587, 0.0966069978279781, 0.09816517521230032, 0.09972335259662256, 0.10128152998094478, 0.10283970736526701, 0.10439788474958923, 0.10595606213391147, 0.1075142395182337, 0.10907241690255592, 0.11063059428687816, 0.11218877167120038, 0.11374694905552261, 0.11530512643984482, 0.11686330382416706, 0.11842148120848928, 0.11997965859281151, 0.12153783597713375, 0.12309601336145597, 0.1246541907457782, 0.12621236813010042, 0.12777054551442266, 0.1293287228987449, 0.13088690028306713, 0.13244507766738933, 0.13400325505171154, 0.13556143243603377, 0.137119609820356, 0.13867778720467824, 0.14023596458900048, 0.14179414197332268, 0.14335231935764492, 0.14491049674196715, 0.1464686741262894, 0.14802685151061162, 0.14958502889493383, 0.15114320627925606, 0.1527013836635783, 0.15425956104790053, 0.15581773843222274, 0.15737591581654498, 0.15893409320086718, 0.16049227058518942, 0.16205044796951165, 0.1636086253538339, 0.16516680273815607, 0.1667249801224783, 0.16828315750680053, 0.16984133489112277, 0.171399512275445, 0.1729576896597672, 0.17451586704408945, 0.17607404442841168, 0.17763222181273391, 0.17919039919705612, 0.18074857658137836, 0.1823067539657006, 0.18386493135002283, 0.18542310873434506, 0.18698128611866727, 0.1885394635029895, 0.19009764088731174, 0.19165581827163397, 0.1932139956559562, 0.1947721730402784, 0.19633035042460065, 0.19788852780892288, 0.19944670519324512, 0.20100488257756735, 0.20256305996188956, 0.20412123734621176, 0.205679414730534, 0.2072375921148562, 0.20879576949917844, 0.21035394688350068, 0.2119121242678229, 0.21347030165214514, 0.21502847903646735, 0.2165866564207896]</AoA>
-          <CD is_input="False">[0.02072447917842244, 0.020726680188796958, 0.02073482115899231, 0.020749001223305138, 0.020769319516032083, 0.02079587517146979, 0.02082876732391489, 0.02086809510766402, 0.020913957657013826, 0.020966454106260937, 0.021025683589702, 0.021091745241633642, 0.02116473819635252, 0.021244761588155258, 0.021331914551338496, 0.021426296220198888, 0.021528005729033052, 0.02163714221213764, 0.02175380480380928, 0.021878092638344622, 0.022010104850040298, 0.022149940573192944, 0.02229769894209921, 0.022453479091055724, 0.02261738015435913, 0.022789501266306064, 0.022969941561193162, 0.023158800173317073, 0.023356176236974426, 0.02356216888646186, 0.023776877256076016, 0.024000400480113537, 0.024232837692871056, 0.02447428802864521, 0.024724850621732648, 0.02498462460643, 0.025255838398506578, 0.025540746976339526, 0.025839529715091677, 0.026152421343454874, 0.02647971479018358, 0.026821765285666, 0.02717899584022185, 0.02755190426337812, 0.027941071937274985, 0.028347174614584608, 0.028770995579273234, 0.029213441590110086, 0.02967556212560342, 0.030158572569464158, 0.03066388212330013, 0.031193127414979583, 0.03174821299572124, 0.03233136019752748, 0.03294516616909224, 0.033592675340600356, 0.034277466108593196, 0.03500375621031652, 0.03577653110985127, 0.036601700793576705, 0.037486291731565174, 0.03843868248364531, 0.03946889361667794, 0.04058894538611894, 0.041813300193204485, 0.043159411384619026, 0.04464840580904306, 0.04630593507073544, 0.048163240131615576, 0.05025848647838482, 0.052638443372441425, 0.05536060190599577, 0.05849585424883721, 0.062131892651100654, 0.06637753422354951, 0.07136823993591934, 0.07727317860436857, 0.08430429554021421, 0.09272798998965161, 0.10288019766708817, 0.11518593107216098, 0.13018467333392708, 0.14856348168310124, 0.17120027624373949, 0.19922062620557338, 0.23407247779581636, 0.27762480615635354, 0.33229826762935366, 0.40123879025838877, 0.4885489612528698, 0.5553328778733796, 0.5562667081256677, 0.5572154004244738, 0.5581790539040951, 0.5591577676988279, 0.5601516409429689, 0.5611607727708149, 0.5621852623166623, 0.5632252087148081, 0.5642807110995484, 0.5653518686051802, 0.5664387803660001, 0.5675415455163046, 0.5686602631903906, 0.5697950325225545, 0.570945952647093, 0.572113122698303, 0.5732966418104806, 0.5744966091179229, 0.5757131237549262, 0.5769462848557876, 0.5781961915548032, 0.5794629429862701, 0.5807466382844846, 0.5820473765837435, 0.5833652570183434, 0.5847003787225808, 0.5860528408307528, 0.5874227424771555, 0.5888101827960859, 0.5902152609218404, 0.5916380759887157, 0.5930787271310087, 0.5945373134830156, 0.5960139341790334, 0.5975086883533585, 0.5990216751402876, 0.6005529936741175, 0.6021027430891446, 0.6036710225196658, 0.6052579310999775, 0.6068635679643763, 0.6084880322471592, 0.6101314230826225, 0.611793839605063, 0.6134753809487771, 0.6151761462480618, 0.6168962346372134, 0.6186357452505289, 0.6203947772223046, 0.6221734296868373, 0.6239718017784236, 0.6257899926313603, 0.6276281013799437, 0.6294862271584707, 0.6313644691012379, 0.6332629263425418, 0.6351816980166792, 0.6371208832579469, 0.6390805812006412]<!--Input defined by the mission.--><compressibility is_input="False">[0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.0010276577717950224, 0.0010340721788208763, 0.001044851952266096, 0.001060132686525893, 0.001080108176058095, 0.0011050345169542509, 0.0011352355852374634, 0.0011711100561380642, 0.0012131401774996004, 0.0012619025676975858, 0.0013180813764016425, 0.0013824842280843375, 0.0014560614669572966, 0.0015399293424348073, 0.001635397921828059, 0.0017440046987086473, 0.0018675550899986708, 0.0020081712934038637, 0.002168351323321527, 0.0023510404756398656, 0.002559718012603585, 0.002798502537161831, 0.0030722803790988957, 0.0033868623904974157, 0.0037491759071330683, 0.004167500354537878, 0.00465175716527602, 0.00521386746050672, 0.005868194507169543, 0.006632092517652276, 0.007526589206338793, 0.008577237043191297, 0.009815177855832573, 0.01127847799666732, 0.01301380759279717, 0.015078558602135845, 0.017543524060176063, 0.02049629708275611, 0.02404559564634274, 0.02832678158637488, 0.033508924584714314, 0.03980387081838143, 0.047477920399274925, 0.05686690990750556, 0.06839575270841378, 0.08260383279676002, 0.10017810826896235, 0.1219964001147802, 0.1491841783896485, 0.18318929018648408, 0.2258806115128753, 0.27967869957669433, 0.34772938328721664, 0.43413515071955644, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]<!--increment of drag coefficient due to compressibility effects (shock waves) w.r.t. data:aerodynamics:aircraft:cruise:CL--></compressibility><trim is_input="False">[0.0, 5.89e-06, 1.178e-05, 1.767e-05, 2.356e-05, 2.945e-05, 3.534e-05, 4.123e-05, 4.712e-05, 5.3009999999999996e-05, 5.89e-05, 6.479e-05, 7.068e-05, 7.657000000000001e-05, 8.246e-05, 8.834999999999999e-05, 9.424e-05, 0.00010013, 0.00010601999999999999, 0.00011191, 0.0001178, 0.00012369, 0.00012958, 0.00013547, 0.00014136, 0.00014725, 0.00015314000000000001, 0.00015903, 0.00016492, 0.00017081, 0.00017669999999999999, 0.00018259, 0.00018848, 0.00019437, 0.00020026, 0.00020615000000000002, 0.00021203999999999998, 0.00021793, 0.00022382, 0.00022971000000000002, 0.0002356, 0.00024149000000000002, 0.00024738, 0.00025327, 0.00025916, 0.00026505, 0.00027094, 0.00027683000000000004, 0.00028272, 0.00028861, 0.0002945, 0.00030039, 0.00030628000000000003, 0.00031217, 0.00031806, 0.00032395000000000004, 0.00032984, 0.00033573, 0.00034162, 0.00034751, 0.00035339999999999997, 0.00035929, 0.00036518, 0.00037107, 0.00037696, 0.00038285, 0.00038874, 0.00039463000000000004, 0.00040052, 0.00040641000000000006, 0.00041230000000000005, 0.00041819, 0.00042407999999999996, 0.00042997, 0.00043586, 0.00044175, 0.00044764, 0.00045353, 0.00045942000000000004, 0.00046531000000000003, 0.0004712, 0.00047709000000000006, 0.00048298000000000004, 0.0004888700000000001, 0.00049476, 0.0005006499999999999, 0.00050654, 0.00051243, 0.00051832, 0.00052421, 0.0005301, 0.00053599, 0.00054188, 0.00054777, 0.0005536600000000001, 0.00055955, 0.00056544, 0.00057133, 0.00057722, 0.00058311, 0.000589, 0.00059489, 0.00060078, 0.00060667, 0.0006125600000000001, 0.00061845, 0.00062434, 0.0006302300000000001, 0.00063612, 0.00064201, 0.0006479000000000001, 0.00065379, 0.00065968, 0.0006655700000000001, 0.00067146, 0.0006773500000000001, 0.00068324, 0.0006891299999999999, 0.00069502, 0.00070091, 0.0007067999999999999, 0.00071269, 0.00071858, 0.00072447, 0.00073036, 0.00073625, 0.00074214, 0.00074803, 0.00075392, 0.00075981, 0.0007657, 0.0007715900000000001, 0.00077748, 0.00078337, 0.0007892600000000001, 0.0007951500000000001, 0.00080104, 0.0008069300000000001, 0.0008128200000000001, 0.00081871, 0.0008246000000000001, 0.0008304899999999999, 0.00083638, 0.00084227, 0.0008481599999999999, 0.00085405, 0.00085994, 0.0008658299999999999, 0.00087172, 0.00087761]<!--increment of drag coefficient due to aircraft trim w.r.t. data:aerodynamics:aircraft:cruise:CL--></trim></CD>
-          <CD0 is_input="False">[0.019698950688100094, 0.019691558143439234, 0.01968269844852846, 0.01967247073766441, 0.019660974145143728, 0.019648307805263054, 0.01963457085231902, 0.01961986242060827, 0.019604281644427436, 0.019587927658073163, 0.019570899595842087, 0.019553296592030846, 0.019535217780936084, 0.019516762296854426, 0.019498029274082528, 0.019479117846917023, 0.019460127149654543, 0.019441156316591733, 0.01942230448202523, 0.019403670780251674, 0.019385354345567696, 0.019367454312269945, 0.019350069814655056, 0.01933329998701967, 0.019317243963660417, 0.019302000878873946, 0.01928766986695689, 0.01927435006220589, 0.019262140598917583, 0.019251140611388606, 0.019241449233915603, 0.019233165600795205, 0.01922638884632406, 0.0192212181047988, 0.019217752510516068, 0.0192160911977725, 0.019216333300864735, 0.01921857795408941, 0.019222924291743167, 0.01922947144812264, 0.019238318557524472, 0.019249564754245305, 0.01926330917258177, 0.01927965094683051, 0.019298689211288158, 0.019320523100251362, 0.01934525174801675, 0.019372974288880972, 0.01940378985714066, 0.01943779758709245, 0.01947509661303299, 0.01951578606925891, 0.019559965090066852, 0.019607732809753458, 0.019659188362615362, 0.019714430882949198, 0.019773559505051618, 0.01983667336321925, 0.019903871591748737, 0.01997525332493671, 0.020050917697079826, 0.020130963842474703, 0.02021549089541799, 0.020304597990206324, 0.020398384261136347, 0.020496948842504692, 0.020600390868608, 0.020708809473742915, 0.02082230379220607, 0.020940972958294102, 0.02106491610630365, 0.021194232370531352, 0.021329020885273855, 0.02146938078482779, 0.0216154112034898, 0.021767211275556517, 0.02192488013532459, 0.02208851691709065, 0.02225822075515133, 0.022434090783803286, 0.02261622613734314, 0.022804725950067543, 0.022999689356273126, 0.02320121549025653, 0.02340940348631439, 0.02362435247874335, 0.023846161601840048, 0.024074929989901118, 0.024310756777223205, 0.024553741098102946, 0.024803982086836977, 0.025061578877721938, 0.025326630605054468, 0.02559923640313121, 0.025879495406248794, 0.026167506748703856, 0.026463369564793053, 0.026767182988813004, 0.02707904615506036, 0.027399058197831755, 0.027727318251423827, 0.028063925450133212, 0.028408978928256563, 0.028762577820090503, 0.029124821259931676, 0.029495808382076716, 0.02987563832082227, 0.030264410210464984, 0.030662223185301478, 0.03106917637962838, 0.03148536892774236, 0.03191089996394006, 0.032345868622518086, 0.03279037403777311, 0.03324451534400172, 0.03370839167550061, 0.03418210216656639, 0.034665745951495706, 0.035159422164585195, 0.03566322994013151, 0.036177268412431275, 0.03670163671578112, 0.03723643398447771, 0.037781759352817655, 0.0383377119550976, 0.03890439092561421, 0.03948189539866408, 0.040070324508543885, 0.04066977738955025, 0.04128035317597982, 0.04190215100212921, 0.0425352700022951, 0.0431798093107741, 0.043835868061862855, 0.044503545389858, 0.04518294042905618, 0.04587415231375404, 0.046577280178248186, 0.04729242315683529, 0.048019680383811984, 0.048759150993474894, 0.04951093412012067, 0.05027512889804594, 0.05105183446154738, 0.05184114994492158, 0.052643174482465194, 0.053458007208474864, 0.05428574725724724, 0.05512649376307895, 0.05598034586026665]<!--profile drag coefficient for whole aircraft in cruise conditions w.r.t. data:aerodynamics:aircraft:cruise:CL--><clean is_input="False">[0.017794697396684836, 0.01778801947270227, 0.01778001622458716, 0.017770777203546487, 0.01776039196078723, 0.017748950047516372, 0.017736541014940883, 0.017723254414267746, 0.017709179796703934, 0.01769440671345643, 0.017679024715732208, 0.017663123354738245, 0.017646792181681525, 0.01763012074776902, 0.01761319860420771, 0.01759611530220458, 0.017578960392966594, 0.017561823427700744, 0.017544793957613998, 0.017527961533913335, 0.017511415707805737, 0.01749524603049818, 0.01747954205319764, 0.0174643933271111, 0.017449889403445534, 0.01743611983340792, 0.017423174168205238, 0.017411141959044463, 0.017400112757132578, 0.017390176113676555, 0.017381421579883375, 0.017373938706960013, 0.017367817046113454, 0.017363146148550668, 0.01736001556547864, 0.017358514848104342, 0.017358733547634755, 0.017360761215276854, 0.017364687402237622, 0.017370601659724032, 0.017378593538943065, 0.0173887525911017, 0.017401168367406912, 0.017415930419065678, 0.017433128297284977, 0.01745285155327179, 0.01747518973823309, 0.017500232403375865, 0.01752806909990708, 0.017558789379033716, 0.01759248279196276, 0.01762923888990118, 0.017669147224055954, 0.01771229734563407, 0.017758778805842496, 0.017808681155888212, 0.0178620939469782, 0.017919106730319434, 0.017979809057118892, 0.018044290478583552, 0.0181126405459204, 0.018184948810336398, 0.018261304823038536, 0.01834179813523379, 0.018426518298129135, 0.018515554862931553, 0.01860899738084802, 0.01870693540308551, 0.01880945848085101, 0.01891665616535149, 0.01902861800779393, 0.019145433559385305, 0.0192671923713326, 0.019393983994842788, 0.01952589798112285, 0.01966302388137976, 0.0198054512468205, 0.019953269628652046, 0.020106568578081373, 0.020265437646315467, 0.020429966384561297, 0.02060024434402585, 0.020776361075916093, 0.020958406131439015, 0.021146469061801582, 0.02134063941821078, 0.02154100675187359, 0.02174766061399698, 0.021960690555787938, 0.022180186128453436, 0.022406236883200453, 0.02263893237123597, 0.02287836214376696, 0.023124615752000404, 0.02337778274714328, 0.023637952680402557, 0.023905215102985232, 0.024179659566098265, 0.024461375620948644, 0.024750452818743343, 0.02504698071068934, 0.02535104884799361, 0.025662746781863144, 0.025982164063504908, 0.026309390244125878, 0.026644514874933037, 0.026987627507133367, 0.027338817691933845, 0.027698174980541442, 0.028065788924163126, 0.028441749074005897, 0.02882614498127674, 0.0292190661971826, 0.029620602272930483, 0.030030842759727335, 0.03044987720878017, 0.03087779517129595, 0.03131468619848165, 0.03176063984154425, 0.03221574565169074, 0.032680093180128086, 0.03315377197806326, 0.03363687159670326, 0.034129481587255046, 0.0346316915009256, 0.035143590888921904, 0.03566526930245092, 0.036196816292719654, 0.03673832141093506, 0.03728987420830414, 0.037851564236033836, 0.038423481045331165, 0.03900571418740308, 0.039598353213456575, 0.04020148767469861, 0.040815207122336175, 0.04143960110757625, 0.0420747591816258, 0.04272077089569181, 0.043377725800981266, 0.044045713448701125, 0.044724823390058385, 0.045415145176260004, 0.046116768358513006, 0.046829782488024316, 0.04755427711600093, 0.04829034179364983, 0.04903806607217799, 0.0497975395027924, 0.05056885163670004]<!--like data:aerodynamics:aircraft:cruise:CD0 but without parasitic drag--></clean><parasitic is_input="False">[0.001904253291415258, 0.0019035386707369657, 0.0019026822239412988, 0.001901693534117923, 0.0019005821843564967, 0.0018993577577466822, 0.001898029837378138, 0.0018966080063405229, 0.0018951018477235022, 0.0018935209446167348, 0.001891874880109879, 0.0018901732372926007, 0.0018884255992545583, 0.001886641549085407, 0.0018848306698748159, 0.0018830025447124435, 0.0018811667566879485, 0.0018793328888909895, 0.001877510524411232, 0.0018757092463383383, 0.00187393863776196, 0.0018722082817717658, 0.0018705277614574148, 0.0018689066599085688, 0.001867354560214883, 0.0018658810454660266, 0.001864495698751651, 0.0018632081031614255, 0.001862027841785005, 0.0018609644977120518, 0.0018600276540322279, 0.001859226893835192, 0.001858571800210606, 0.001858071956248132, 0.001857736945037429, 0.0018575763496681587, 0.0018575997532299798, 0.0018578167388125545, 0.0018582368895055448, 0.0018588697883986094, 0.0018597250185814068, 0.0018608121631436061, 0.001862140805174859, 0.001863720527764831, 0.001865560914003181, 0.0018676715469795706, 0.0018700620097836587, 0.0018727418855051074, 0.0018757207572335823, 0.0018790082080587349, 0.001882613821070231, 0.0018865471793577324, 0.001890817866010898, 0.0018954354641193896, 0.0019004095567728661, 0.001905749727060986, 0.0019114655580734184, 0.001917566632899815, 0.0019240625346298446, 0.001930962846353159, 0.0019382771511594274, 0.0019460150321383048, 0.0019541860723794532, 0.001962799854972535, 0.001971865963007212, 0.0019813939795731393, 0.0019913934877599827, 0.0020018740706574042, 0.002012845311355059, 0.0020243167929426126, 0.00203629809850972, 0.002048798811146047, 0.002061828513941256, 0.002075396789985001, 0.002089513222366949, 0.0021041873941767576, 0.0021194288885040893, 0.0021352472884386027, 0.0021516521770699563, 0.0021686531374878193, 0.0021862597527818432, 0.0022044816060416937, 0.002223328280357033, 0.0022428093588175158, 0.002262934424512808, 0.0022837130605325683, 0.0023051548499664586, 0.0023272693759041375, 0.0023500662214352673, 0.00237355496964951, 0.002397745203636524, 0.0024226465064859683, 0.002448268461287508, 0.002474620651130806, 0.002501712659105513, 0.0025295540683012985, 0.002558154461807821, 0.0025875234227147395, 0.0026176705341117157, 0.0026486053790884118, 0.0026803375407344864, 0.0027128766021396016, 0.0027462321463934194, 0.002780413756585595, 0.002815431015805798, 0.002851293507143679, 0.0028880108136889043, 0.0029255925185311393, 0.0029640482047600357, 0.0030033874554652555, 0.0030436198537364643, 0.003084754982663321, 0.003126802425335487, 0.003169771764842625, 0.003213672584274383, 0.0032585144667204406, 0.0033043069952704424, 0.0033510597530140573, 0.003398782323040944, 0.003447484288440772, 0.0034971752323031888, 0.003547864737717857, 0.003599562387774445, 0.0036522777655626087, 0.003706020454172003, 0.0037608000366923036, 0.003816626096213159, 0.003873508215824231, 0.003931455978615189, 0.003990478967675681, 0.0040505867660953765, 0.004111788956963937, 0.0041740951233710175, 0.0042375148484062805, 0.004302057715159388, 0.004367733306720002, 0.004434551206177785, 0.004502520996622385, 0.004571652261143477, 0.004641954582830718, 0.004713437544773769, 0.004786110730062285, 0.004859983721785935, 0.0049350661030343745, 0.005011367456897266, 0.005088897366464264, 0.005167665414825037, 0.005247681185069249, 0.005328954260286553, 0.0054114942235666125]<!--estimated parasitic drag for whole aircraft in cruise conditions (no high-lift) w.r.t. data:aerodynamics:aircraft:low_speed:CL--></parasitic></CD0>
+          <AoA units="rad" is_input="False">[-0.015581773843222199, -0.01402359645889998, -0.012465419074577759, -0.01090724169025554, -0.00934906430593332, -0.007790886921611099, -0.00623270953728888, -0.00467453215296666, -0.00311635476864444, -0.0015581773843222212, 0.0, 0.001558177384322219, 0.003116354768644438, 0.00467453215296666, 0.00623270953728888, 0.007790886921611098, 0.00934906430593332, 0.01090724169025554, 0.012465419074577757, 0.014023596458899978, 0.015581773843222199, 0.017139951227544418, 0.01869812861186664, 0.02025630599618886, 0.021814483380511077, 0.023372660764833297, 0.024930838149155518, 0.02648901553347774, 0.02804719291779996, 0.029605370302122173, 0.031163547686444394, 0.032721725070766615, 0.034279902455088836, 0.035838079839411056, 0.03739625722373328, 0.0389544346080555, 0.04051261199237772, 0.04207078937669994, 0.04362896676102216, 0.04518714414534438, 0.0467453215296666, 0.04830349891398882, 0.04986167629831103, 0.05141985368263325, 0.05297803106695547, 0.05453620845127769, 0.05609438583559991, 0.05765256321992213, 0.059210740604244354, 0.060768917988566575, 0.062327095372888795, 0.06388527275721102, 0.06544345014153324, 0.06700162752585546, 0.06855980491017769, 0.0701179822944999, 0.07167615967882213, 0.07323433706314435, 0.07479251444746655, 0.07635069183178878, 0.077908869216111, 0.07946704660043322, 0.08102522398475544, 0.08258340136907766, 0.08414157875339988, 0.0856997561377221, 0.08725793352204432, 0.08881611090636654, 0.09037428829068876, 0.09193246567501098, 0.0934906430593332, 0.09504882044365541, 0.09660699782797763, 0.09816517521229985, 0.09972335259662207, 0.1012815299809443, 0.10283970736526651, 0.10439788474958873, 0.10595606213391096, 0.10751423951823318, 0.1090724169025554, 0.11063059428687762, 0.11218877167119984, 0.11374694905552206, 0.11530512643984427, 0.11686330382416649, 0.11842148120848871, 0.11997965859281093, 0.12153783597713315, 0.12309601336145537, 0.12465419074577759, 0.1262123681300998, 0.12777054551442205, 0.12932872289874425, 0.1308869002830665, 0.1324450776673887, 0.1340032550517109, 0.13556143243603314, 0.13711960982035534, 0.13867778720467758, 0.14023596458899978, 0.14179414197332202, 0.14335231935764423, 0.14491049674196646, 0.14646867412628867, 0.1480268515106109, 0.1495850288949331, 0.15114320627925534, 0.15270138366357755, 0.15425956104789978, 0.155817738432222, 0.1573759158165442, 0.15893409320086643, 0.16049227058518864, 0.16205044796951087, 0.16360862535383308, 0.1651668027381553, 0.1667249801224775, 0.16828315750679973, 0.16984133489112194, 0.17139951227544417, 0.17295768965976638, 0.1745158670440886, 0.17607404442841082, 0.17763222181273305, 0.17919039919705526, 0.1807485765813775, 0.1823067539656997, 0.18386493135002194, 0.18542310873434414, 0.18698128611866638, 0.18853946350298859, 0.19009764088731082, 0.19165581827163303, 0.19321399565595526, 0.19477217304027747, 0.1963303504245997, 0.1978885278089219, 0.19944670519324414, 0.20100488257756635, 0.2025630599618886, 0.20412123734621077, 0.205679414730533, 0.2072375921148552, 0.20879576949917744, 0.21035394688349965, 0.21191212426782188, 0.2134703016521441, 0.21502847903646632, 0.21658665642078853]</AoA>
+          <CD is_input="False">[0.020724479178435347, 0.020726680188809816, 0.02073482115900512, 0.020749001223317905, 0.020769319516044805, 0.020795875171482462, 0.020828767323927518, 0.020868095107676607, 0.020913957657026364, 0.020966454106273433, 0.021025683589714454, 0.02109174524164606, 0.021164738196364895, 0.0212447615881676, 0.0213319145513508, 0.02142629622021115, 0.02152800572904528, 0.02163714221214983, 0.021753804803821438, 0.02187809263835674, 0.02201010485005239, 0.022149940573205, 0.022297698942111237, 0.022453479091067718, 0.02261738015437109, 0.022789501266317996, 0.02296994156120507, 0.023158800173328952, 0.023356176236986277, 0.023562168886473688, 0.023776877256087812, 0.024000400480125316, 0.02423283769288281, 0.02447428802865694, 0.024724850621744357, 0.024984624606441682, 0.025255838398518242, 0.025540746976351173, 0.025839529715103303, 0.026152421343466483, 0.026479714790195175, 0.026821765285677576, 0.027178995840233408, 0.027551904263389663, 0.027941071937286517, 0.02834717461459612, 0.02877099557928474, 0.02921344159012158, 0.029675562125614903, 0.030158572569475635, 0.0306638821233116, 0.031193127414991043, 0.03174821299573269, 0.03233136019753892, 0.03294516616910368, 0.0335926753406118, 0.034277466108604625, 0.035003756210327946, 0.03577653110986269, 0.036601700793588134, 0.037486291731576596, 0.03843868248365674, 0.03946889361668938, 0.04058894538613037, 0.04181330019321591, 0.04315941138463046, 0.0446484058090545, 0.04630593507074688, 0.04816324013162704, 0.05025848647839627, 0.05263844337245289, 0.055360601906007244, 0.05849585424884869, 0.06213189265111215, 0.06637753422356102, 0.07136823993593086, 0.0772731786043801, 0.08430429554022575, 0.09272798998966318, 0.10288019766709974, 0.11518593107217259, 0.1301846733339387, 0.14856348168311287, 0.17120027624375111, 0.19922062620558506, 0.23407247779582807, 0.27762480615636526, 0.3322982676293653, 0.40123879025840054, 0.4885489612528816, 0.5553328778733915, 0.5562667081256795, 0.5572154004244856, 0.5581790539041069, 0.5591577676988397, 0.5601516409429808, 0.561160772770827, 0.5621852623166743, 0.5632252087148201, 0.5642807110995604, 0.5653518686051923, 0.5664387803660123, 0.5675415455163169, 0.5686602631904029, 0.5697950325225668, 0.5709459526471053, 0.5721131226983153, 0.573296641810493, 0.5744966091179353, 0.5757131237549387, 0.5769462848558, 0.5781961915548157, 0.5794629429862826, 0.5807466382844972, 0.5820473765837562, 0.5833652570183562, 0.5847003787225936, 0.5860528408307656, 0.5874227424771684, 0.5888101827960988, 0.5902152609218534, 0.5916380759887288, 0.5930787271310217, 0.5945373134830287, 0.5960139341790465, 0.5975086883533717, 0.5990216751403009, 0.6005529936741308, 0.602102743089158, 0.6036710225196792, 0.6052579310999909, 0.6068635679643899, 0.6084880322471728, 0.6101314230826361, 0.6117938396050766, 0.613475380948791, 0.6151761462480757, 0.6168962346372274, 0.6186357452505429, 0.6203947772223187, 0.6221734296868515, 0.6239718017784379, 0.6257899926313745, 0.6276281013799582, 0.6294862271584852, 0.6313644691012525, 0.6332629263425565, 0.635181698016694, 0.6371208832579616, 0.6390805812006559]<!--Input defined by the mission.--><compressibility is_input="False">[0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.0010276577717950224, 0.0010340721788208763, 0.001044851952266096, 0.001060132686525893, 0.001080108176058095, 0.0011050345169542509, 0.0011352355852374634, 0.0011711100561380642, 0.0012131401774996004, 0.0012619025676975858, 0.0013180813764016425, 0.0013824842280843375, 0.0014560614669572966, 0.0015399293424348073, 0.001635397921828059, 0.0017440046987086473, 0.0018675550899986708, 0.0020081712934038637, 0.002168351323321527, 0.0023510404756398656, 0.002559718012603585, 0.002798502537161831, 0.0030722803790988957, 0.0033868623904974157, 0.0037491759071330683, 0.004167500354537878, 0.00465175716527602, 0.00521386746050672, 0.005868194507169543, 0.006632092517652276, 0.007526589206338793, 0.008577237043191297, 0.009815177855832573, 0.01127847799666732, 0.013013807592797168, 0.015078558602135845, 0.017543524060176063, 0.02049629708275611, 0.02404559564634274, 0.02832678158637488, 0.033508924584714314, 0.03980387081838143, 0.047477920399274925, 0.05686690990750556, 0.06839575270841378, 0.08260383279676002, 0.10017810826896235, 0.1219964001147802, 0.1491841783896485, 0.18318929018648408, 0.2258806115128753, 0.27967869957669433, 0.34772938328721664, 0.43413515071955644, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]<!--increment of drag coefficient due to compressibility effects (shock waves) w.r.t. data:aerodynamics:aircraft:cruise:CL--></compressibility><trim is_input="False">[0.0, 5.89e-06, 1.178e-05, 1.767e-05, 2.356e-05, 2.945e-05, 3.534e-05, 4.123e-05, 4.712e-05, 5.3009999999999996e-05, 5.89e-05, 6.479e-05, 7.068e-05, 7.657000000000001e-05, 8.246e-05, 8.834999999999999e-05, 9.424e-05, 0.00010013, 0.00010601999999999999, 0.00011191, 0.0001178, 0.00012369, 0.00012958, 0.00013547, 0.00014136, 0.00014725, 0.00015314000000000001, 0.00015903, 0.00016492, 0.00017081, 0.00017669999999999999, 0.00018259, 0.00018848, 0.00019437, 0.00020026, 0.00020615000000000002, 0.00021203999999999998, 0.00021793, 0.00022382, 0.00022971000000000002, 0.0002356, 0.00024149000000000002, 0.00024738, 0.00025327, 0.00025916, 0.00026505, 0.00027094, 0.00027683000000000004, 0.00028272, 0.00028861, 0.0002945, 0.00030039, 0.00030628000000000003, 0.00031217, 0.00031806, 0.00032395000000000004, 0.00032984, 0.00033573, 0.00034162, 0.00034751, 0.00035339999999999997, 0.00035929, 0.00036518, 0.00037107, 0.00037696, 0.00038285, 0.00038874, 0.00039463000000000004, 0.00040052, 0.00040641000000000006, 0.00041230000000000005, 0.00041819, 0.00042407999999999996, 0.00042997, 0.00043586, 0.00044175, 0.00044764, 0.00045353, 0.00045942000000000004, 0.00046531000000000003, 0.0004712, 0.00047709000000000006, 0.00048298000000000004, 0.0004888700000000001, 0.00049476, 0.0005006499999999999, 0.00050654, 0.00051243, 0.00051832, 0.00052421, 0.0005301, 0.00053599, 0.00054188, 0.00054777, 0.0005536600000000001, 0.00055955, 0.00056544, 0.00057133, 0.00057722, 0.00058311, 0.000589, 0.00059489, 0.00060078, 0.00060667, 0.0006125600000000001, 0.00061845, 0.00062434, 0.0006302300000000001, 0.00063612, 0.00064201, 0.0006479000000000001, 0.00065379, 0.00065968, 0.0006655700000000001, 0.00067146, 0.0006773500000000001, 0.00068324, 0.0006891299999999999, 0.00069502, 0.00070091, 0.0007067999999999999, 0.00071269, 0.00071858, 0.00072447, 0.00073036, 0.00073625, 0.00074214, 0.00074803, 0.00075392, 0.00075981, 0.0007657, 0.0007715900000000001, 0.00077748, 0.00078337, 0.0007892600000000001, 0.0007951500000000001, 0.00080104, 0.0008069300000000001, 0.0008128200000000001, 0.00081871, 0.0008246000000000001, 0.0008304899999999999, 0.00083638, 0.00084227, 0.0008481599999999999, 0.00085405, 0.00085994, 0.0008658299999999999, 0.00087172, 0.00087761]<!--increment of drag coefficient due to aircraft trim w.r.t. data:aerodynamics:aircraft:cruise:CL--></trim></CD>
+          <CD0 is_input="False">[0.019698950688113, 0.019691558143452092, 0.01968269844854127, 0.019672470737677177, 0.019660974145156447, 0.01964830780527572, 0.019634570852331643, 0.019619862420620846, 0.019604281644439964, 0.019587927658085647, 0.019570899595854525, 0.01955329659204324, 0.01953521778094843, 0.019516762296866736, 0.019498029274094792, 0.019479117846929243, 0.01946012714966672, 0.01944115631660387, 0.019422304482037328, 0.019403670780263723, 0.01938535434557971, 0.01936745431228192, 0.01935006981466699, 0.019333299987031562, 0.019317243963672272, 0.01930200087888576, 0.019287669866968667, 0.01927435006221763, 0.019262140598929285, 0.019251140611400274, 0.01924144923392723, 0.019233165600806804, 0.01922638884633562, 0.019221218104810325, 0.019217752510527555, 0.019216091197783954, 0.019216333300876152, 0.019218577954100795, 0.01922292429175452, 0.019229471448133962, 0.01923831855753576, 0.019249564754256564, 0.019263309172592995, 0.019279650946841705, 0.019298689211299323, 0.019320523100262495, 0.019345251748027856, 0.01937297428889205, 0.01940378985715171, 0.019437797587103473, 0.019475096613043984, 0.01951578606926988, 0.019559965090077795, 0.01960773280976437, 0.019659188362626253, 0.019714430882960064, 0.019773559505062457, 0.019836673363230067, 0.019903871591759527, 0.01997525332494748, 0.02005091769709057, 0.020130963842485423, 0.020215490895428692, 0.020304597990217006, 0.020398384261147005, 0.020496948842515333, 0.02060039086861862, 0.020708809473753514, 0.02082230379221665, 0.020940972958304657, 0.02106491610631419, 0.02119423237054188, 0.02132902088528436, 0.021469380784838284, 0.021615411203500277, 0.021767211275566974, 0.021924880135335032, 0.022088516917101075, 0.022258220755161748, 0.022434090783813684, 0.022616226137353528, 0.022804725950077914, 0.022999689356283482, 0.023201215490266876, 0.023409403486324726, 0.023624352478753677, 0.023846161601850362, 0.024074929989911422, 0.0243107567772335, 0.024553741098113233, 0.024803982086847254, 0.025061578877732204, 0.02532663060506473, 0.02559923640314146, 0.02587949540625904, 0.026167506748714094, 0.026463369564803288, 0.026767182988823232, 0.027079046155070584, 0.027399058197841976, 0.027727318251434045, 0.028063925450143423, 0.028408978928266774, 0.028762577820100707, 0.029124821259941883, 0.02949580838208692, 0.029875638320832475, 0.030264410210475188, 0.030662223185311675, 0.03106917637963859, 0.03148536892775257, 0.031910899963950266, 0.03234586862252829, 0.03279037403778331, 0.03324451534401193, 0.033708391675510825, 0.034182102166576606, 0.034665745951505934, 0.03515942216459543, 0.035663229940141754, 0.036177268412441524, 0.03670163671579136, 0.03723643398448795, 0.03778175935282791, 0.03833771195510788, 0.03890439092562449, 0.03948189539867437, 0.04007032450855419, 0.04066977738956057, 0.041280353175990145, 0.04190215100213955, 0.04253527000230545, 0.04317980931078446, 0.04383586806187322, 0.04450354538986839, 0.04518294042906657, 0.045874152313764446, 0.04657728017825862, 0.04729242315684573, 0.04801968038382244, 0.04875915099348538, 0.04951093412013117, 0.05027512889805645, 0.05105183446155789, 0.051841149944932115, 0.05264317448247577, 0.053458007208485446, 0.05428574725725784, 0.05512649376308958, 0.0559803458602773]<!--profile drag coefficient for whole aircraft in cruise conditions w.r.t. data:aerodynamics:aircraft:cruise:CL--><clean is_input="False">[0.017794697396695484, 0.01778801947271287, 0.017780016224597718, 0.017770777203557006, 0.01776039196079771, 0.017748950047526805, 0.017736541014951274, 0.017723254414278095, 0.01770917979671424, 0.017694406713466698, 0.017679024715742436, 0.017663123354748435, 0.017646792181691677, 0.017630120747779133, 0.017613198604217787, 0.017596115302214617, 0.017578960392976593, 0.017561823427710704, 0.017544793957623924, 0.017527961533923223, 0.01751141570781559, 0.017495246030507998, 0.017479542053207425, 0.01746439332712085, 0.017449889403455248, 0.0174361198334176, 0.017423174168214883, 0.017411141959054077, 0.017400112757142157, 0.017390176113686102, 0.017381421579892888, 0.0173739387069695, 0.017367817046122905, 0.01736314614856009, 0.017360015565488027, 0.0173585148481137, 0.01735873354764408, 0.017360761215286152, 0.01736468740224689, 0.01737060165973327, 0.017378593538952273, 0.01738875259111088, 0.01740116836741606, 0.0174159304190748, 0.01743312829729407, 0.017452851553280857, 0.01747518973824213, 0.017500232403384875, 0.017528069099916062, 0.017558789379042674, 0.01759248279197169, 0.01762923888991008, 0.017669147224064832, 0.01771229734564292, 0.017758778805851323, 0.017808681155897014, 0.017862093946986974, 0.017919106730328184, 0.017979809057127618, 0.018044290478592254, 0.018112640545929072, 0.018184948810345047, 0.018261304823047164, 0.018341798135242393, 0.018426518298137715, 0.01851555486294011, 0.01860899738085655, 0.01870693540309402, 0.018809458480859496, 0.01891665616535995, 0.019028618007802367, 0.019145433559393722, 0.01926719237134099, 0.019393983994851163, 0.0195258979811312, 0.019663023881388086, 0.019805451246828806, 0.019953269628660328, 0.020106568578089637, 0.020265437646323707, 0.020429966384569516, 0.020600244344034045, 0.020776361075924267, 0.020958406131447168, 0.021146469061809715, 0.021340639418218895, 0.02154100675188168, 0.02174766061400505, 0.021960690555795987, 0.022180186128461465, 0.02240623688320846, 0.022638932371243953, 0.022878362143774925, 0.023124615752008346, 0.023377782747151202, 0.02363795268041046, 0.023905215102993115, 0.024179659566106126, 0.024461375620956485, 0.024750452818751167, 0.025046980710697143, 0.02535104884800139, 0.025662746781870905, 0.025982164063512645, 0.0263093902441336, 0.026644514874940736, 0.026987627507141045, 0.027338817691941505, 0.027698174980549075, 0.028065788924170748, 0.028441749074013496, 0.028826144981284312, 0.02921906619719015, 0.029620602272938015, 0.030030842759734853, 0.030449877208787664, 0.03087779517130342, 0.0313146861984891, 0.03176063984155168, 0.03221574565169816, 0.03268009318013548, 0.03315377197807062, 0.033636871596710596, 0.03412948158726237, 0.034631691500932905, 0.03514359088892919, 0.03566526930245818, 0.0361968162927269, 0.03673832141094229, 0.03728987420831134, 0.03785156423604102, 0.038423481045338326, 0.03900571418741022, 0.03959835321346368, 0.04020148767470571, 0.04081520712234324, 0.041439601107583296, 0.04207475918163283, 0.042720770895698805, 0.04337772580098824, 0.044045713448708085, 0.04472482339006532, 0.045415145176266915, 0.046116768358519876, 0.046829782488031164, 0.04755427711600777, 0.048290341793656634, 0.04903806607218478, 0.049797539502799165, 0.050568851636706776]<!--like data:aerodynamics:aircraft:cruise:CD0 but without parasitic drag--></clean><parasitic is_input="False">[0.0019042532914175167, 0.0019035386707392209, 0.0019026822239435505, 0.0019016935341201711, 0.001900582184358738, 0.0018993577577489165, 0.001898029837380369, 0.0018966080063427503, 0.0018951018477257227, 0.0018935209446189483, 0.001891874880112089, 0.0018901732372948038, 0.0018884255992567545, 0.0018866415490876032, 0.001884830669877005, 0.0018830025447146258, 0.0018811667566901273, 0.0018793328888931649, 0.001877510524413404, 0.0018757092463404998, 0.0018739386377641214, 0.0018722082817739204, 0.0018705277614595658, 0.001868906659910713, 0.0018673545602170237, 0.0018658810454681603, 0.0018644956987537847, 0.0018632081031635522, 0.0018620278417871283, 0.0018609644977141716, 0.0018600276540343408, 0.0018592268938373048, 0.0018585718002127154, 0.0018580719562502346, 0.001857736945039528, 0.0018575763496702542, 0.001857599753232072, 0.0018578167388146431, 0.00185823688950763, 0.001858869788400691, 0.0018597250185834885, 0.0018608121631456843, 0.0018621408051769338, 0.0018637205277669058, 0.0018655609140052522, 0.0018676715469816384, 0.0018700620097857265, 0.0018727418855071752, 0.0018757207572356466, 0.0018790082080607992, 0.0018826138210722952, 0.0018865471793597967, 0.0018908178660129622, 0.0018954354641214505, 0.0019004095567749305, 0.0019057497270630504, 0.0019114655580754827, 0.0019175666329018827, 0.0019240625346319089, 0.0019309628463552268, 0.0019382771511614987, 0.001946015032140376, 0.001954186072381528, 0.001962799854974613, 0.00197186596300929, 0.0019813939795752245, 0.0019913934877620713, 0.002001874070659493, 0.0020128453113571546, 0.002024316792944708, 0.0020362980985118226, 0.0020487988111481566, 0.0020618285139433687, 0.002075396789987121, 0.0020895132223690757, 0.002104187394178888, 0.0021194288885062265, 0.002135247288440747, 0.002151652177072111, 0.0021686531374899773, 0.0021862597527840116, 0.002204481606043869, 0.002223328280359215, 0.0022428093588197084, 0.002262934424515011, 0.0022837130605347818, 0.0023051548499686825, 0.002327269375906372, 0.002350066221437512, 0.0023735549696517685, 0.002397745203638793, 0.002422646506488251, 0.002448268461289805, 0.002474620651133113, 0.0025017126591078374, 0.0025295540683036334, 0.0025581544618101734, 0.0025875234227171057, 0.002617670534114099, 0.002648605379090809, 0.002680337540736901, 0.0027128766021420336, 0.002746232146395869, 0.002780413756588062, 0.002815431015808282, 0.002851293507146184, 0.00288801081369143, 0.0029255925185336824, 0.0029640482047625996, 0.0030033874554678403, 0.0030436198537390734, 0.003084754982665954, 0.003126802425338141, 0.003169771764845293, 0.003213672584277079, 0.0032585144667231607, 0.0033043069952731867, 0.003351059753016833, 0.0033987823230437475, 0.003447484288443596, 0.0034971752323060407, 0.0035478647377207365, 0.0035995623877773525, 0.003652277765565544, 0.0037060204541749728, 0.0037608000366953012, 0.0038166260962161844, 0.0038735082158272913, 0.003931455978618277, 0.003990478967678804, 0.004050586766098534, 0.004111788956967122, 0.004174095123374237, 0.004237514848409542, 0.004302057715162684, 0.004367733306723333, 0.00443455120618115, 0.004502520996625792, 0.004571652261146926, 0.004641954582834201, 0.004713437544777294, 0.004786110730065851, 0.004859983721789536, 0.0049350661030380175, 0.00501136745690095, 0.005088897366467997, 0.005167665414828812, 0.005247681185073065, 0.005328954260290418, 0.005411494223570526]<!--estimated parasitic drag for whole aircraft in cruise conditions (no high-lift) w.r.t. data:aerodynamics:aircraft:low_speed:CL--></parasitic></CD0>
           <CL is_input="False">[0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35000000000000003, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41000000000000003, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47000000000000003, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.5700000000000001, 0.58, 0.59, 0.6, 0.61, 0.62, 0.63, 0.64, 0.65, 0.66, 0.67, 0.68, 0.6900000000000001, 0.7000000000000001, 0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79, 0.8, 0.81, 0.8200000000000001, 0.8300000000000001, 0.84, 0.85, 0.86, 0.87, 0.88, 0.89, 0.9, 0.91, 0.92, 0.93, 0.9400000000000001, 0.9500000000000001, 0.96, 0.97, 0.98, 0.99, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08, 1.09, 1.1, 1.11, 1.12, 1.1300000000000001, 1.1400000000000001, 1.1500000000000001, 1.16, 1.17, 1.18, 1.19, 1.2, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.3, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36, 1.37, 1.3800000000000001, 1.3900000000000001, 1.4000000000000001, 1.41, 1.42, 1.43, 1.44, 1.45, 1.46, 1.47, 1.48, 1.49]<!--Input defined by the mission.--></CL>
           <CL0 is_input="True">0.1</CL0>
-          <CL_alpha units="1/rad" is_input="False">6.4177545513213685<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
-          <L_D_max is_input="False">16.392752942096493<!--max lift/drag ratio in cruise conditions--></L_D_max>
-          <induced_drag_coefficient is_input="False">0.04256959810776591<!--multiply squared lift coefficient by this coefficient to get induced drag coefficient--></induced_drag_coefficient>
-          <optimal_CD is_input="False">0.03233136019752748<!--drag coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CD>
+          <CL_alpha units="1/rad" is_input="False">6.4177545513214<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
+          <L_D_max is_input="False">16.39275294209069<!--max lift/drag ratio in cruise conditions--></L_D_max>
+          <induced_drag_coefficient is_input="False">0.04256959810776808<!--multiply squared lift coefficient by this coefficient to get induced drag coefficient--></induced_drag_coefficient>
+          <optimal_CD is_input="False">0.03233136019753892<!--drag coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CD>
           <optimal_CL is_input="False">0.53<!--lift coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CL>
-          <oswald_coefficient is_input="False">0.7827637261154686<!--Oswald coefficient for cruise conditions--></oswald_coefficient>
+          <oswald_coefficient is_input="False">0.782763726115429<!--Oswald coefficient for cruise conditions--></oswald_coefficient>
         </cruise>
         <landing>
-          <CL_max is_input="False">2.8004141748800144<!--maximum lift coefficient in landing conditions--></CL_max>
-          <CL_max_clean is_input="False">1.5824133961659907<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
-          <CL_max_clean_2D is_input="True">1.94<!--maximum lift coefficient of 2D average profile in landing conditions without high-lift devices--></CL_max_clean_2D>
-          <additional_CL_capacity is_input="False">0.12642476969938432<!--at landing, is equal to (maximum lift coefficient)-(maximum required lift coefficient)--></additional_CL_capacity>
+          <CL_max is_input="False">2.804166289118352<!--maximum lift coefficient in landing conditions--></CL_max>
+          <CL_max_clean is_input="False">1.5861655104043226<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
+          <CL_max_clean_2D is_input="False">1.9446<!--maximum lift coefficient of 2D average profile in landing conditions without high-lift devices--></CL_max_clean_2D>
+          <additional_CL_capacity is_input="False">0.1301768839376538<!--at landing, is equal to (maximum lift coefficient)-(maximum required lift coefficient)--></additional_CL_capacity>
           <mach is_input="False">0.19455259748464468<!--considered Mach number for landing phase--></mach>
         </landing>
       </aircraft>
       <cruise>
         <neutral_point>
-          <x is_input="False">0.42076264790911067<!--X-position of neutral point - X-position of aircraft nose--></x>
+          <x is_input="False">0.42076264790799733<!--X-position of neutral point - X-position of aircraft nose--></x>
         </neutral_point>
       </cruise>
       <fuselage>
         <cruise>
-          <CD0 is_input="False">[0.007141580840659627, 0.007122226202471632, 0.00710304240114483, 0.007084029436679223, 0.007065187309074808, 0.007046516018331587, 0.00702801556444956, 0.007009685947428727, 0.006991527167269088, 0.006973539223970642, 0.00695572211753339, 0.006938075847957331, 0.006920600415242467, 0.006903295819388796, 0.0068861620603963185, 0.006869199138265034, 0.006852407052994945, 0.006835785804586048, 0.006819335393038346, 0.0068030558183518365, 0.006786947080526522, 0.0067710091795624, 0.006755242115459472, 0.006739645888217738, 0.006724220497837197, 0.00670896594431785, 0.0066938822276596975, 0.0066789693478627385, 0.0066642273049269726, 0.0066496560988524005, 0.0066352557296390224, 0.006621026197286837, 0.006606967501795846, 0.006593079643166049, 0.006579362621397446, 0.0065658164364900354, 0.006552441088443819, 0.006539236577258797, 0.006526202902934968, 0.006513340065472333, 0.006500648064870891, 0.0064881269011306435, 0.00647577657425159, 0.006463597084233729, 0.006451588431077062, 0.0064397506147815895, 0.00642808363534731, 0.006416587492774225, 0.006405262187062333, 0.006394107718211634, 0.00638312408622213, 0.006372311291093819, 0.0063616693328267014, 0.006351198211420778, 0.006340897926876048, 0.006330768479192512, 0.006320809868370169, 0.006311022094409021, 0.0063014051573090655, 0.006291959057070305, 0.006282683793692736, 0.006273579367176363, 0.006264645777521182, 0.006255883024727195, 0.006247291108794403, 0.006238870029722804, 0.006230619787512398, 0.006222540382163186, 0.006214631813675168, 0.006206894082048343, 0.006199327187282713, 0.006191931129378276, 0.006184705908335032, 0.0061776515241529825, 0.006170767976832126, 0.006164055266372464, 0.0061575133927739955, 0.00615114235603672, 0.006144942156160639, 0.006138912793145751, 0.0061330542669920576, 0.006127366577699557, 0.00612184972526825, 0.006116503709698138, 0.006111328530989219, 0.006106324189141493, 0.006101490684154961, 0.006096828016029623, 0.006092336184765479, 0.006088015190362528, 0.006083865032820771, 0.006079885712140208, 0.006076077228320838, 0.006072439581362663, 0.00606897277126568, 0.006065676798029891, 0.006062551661655297, 0.006059597362141895, 0.006056813899489688, 0.006054201273698674, 0.006051759484768854, 0.006049488532700227, 0.006047388417492795, 0.006045459139146555, 0.00604370069766151, 0.006042113093037658, 0.006040696325275, 0.006039450394373536, 0.0060383753003332655, 0.0060374710431541885, 0.0060367376228363055, 0.006036175039379615, 0.00603578329278412, 0.006035562383049818, 0.006035512310176709, 0.006035633074164794, 0.006035924675014073, 0.006036387112724546, 0.006037020387296212, 0.006037824498729072, 0.006038799447023125, 0.006039945232178373, 0.006041261854194814, 0.006042749313072448, 0.006044407608811277, 0.006046236741411299, 0.006048236710872515, 0.006050407517194925, 0.006052749160378528, 0.006055261640423325, 0.006057944957329315, 0.006060799111096499, 0.0060638241017248766, 0.006067019929214448, 0.006070386593565214, 0.006073924094777173, 0.006077632432850325, 0.006081511607784672, 0.0060855616195802115, 0.006089782468236945, 0.0060941741537548725, 0.006098736676133994, 0.006103470035374309, 0.006108374231475817, 0.00611344926443852, 0.006118695134262415, 0.006124111840947504, 0.006129699384493788, 0.006135457764901265, 0.006141386982169935]<!--profile drag coefficient for fuselage w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
-          <CnBeta is_input="False">-0.10154900016064428<!--derivative of yawing moment against sideslip angle for fuselage in cruise conditions--></CnBeta>
+          <CD0 is_input="False">[0.007141580840675528, 0.007122226202487489, 0.007103042401160645, 0.007084029436694995, 0.0070651873090905384, 0.007046516018347277, 0.007028015564465208, 0.007009685947444335, 0.006991527167284654, 0.006973539223986169, 0.006955722117548877, 0.006938075847972779, 0.006920600415257876, 0.006903295819404166, 0.00688616206041165, 0.006869199138280329, 0.006852407053010202, 0.006835785804601268, 0.006819335393053529, 0.006803055818366984, 0.006786947080541632, 0.006771009179577476, 0.006755242115474513, 0.006739645888232744, 0.006724220497852169, 0.006708965944332788, 0.006693882227674601, 0.0066789693478776085, 0.0066642273049418105, 0.0066496560988672055, 0.006635255729653795, 0.006621026197301579, 0.006606967501810557, 0.006593079643180728, 0.006579362621412095, 0.006565816436504654, 0.006552441088458408, 0.006539236577273356, 0.006526202902949498, 0.006513340065486835, 0.006500648064885365, 0.006488126901145089, 0.006475776574266008, 0.00646359708424812, 0.006451588431091427, 0.006439750614795927, 0.006428083635361622, 0.006416587492788511, 0.006405262187076594, 0.006394107718225871, 0.006383124086236341, 0.006372311291108006, 0.0063616693328408655, 0.006351198211434919, 0.006340897926890166, 0.006330768479206607, 0.006320809868384242, 0.006311022094423072, 0.006301405157323096, 0.006291959057084314, 0.006282683793706725, 0.006273579367190331, 0.00626464577753513, 0.006255883024741124, 0.0062472911088083125, 0.0062388700297366945, 0.0062306197875262705, 0.00622254038217704, 0.006214631813689005, 0.006206894082062163, 0.006199327187296515, 0.006191931129392062, 0.006184705908348802, 0.006177651524166737, 0.006170767976845865, 0.006164055266386188, 0.006157513392787705, 0.006151142356050416, 0.0061449421561743205, 0.00613891279315942, 0.0061330542670057124, 0.0061273665777132, 0.006121849725281881, 0.006116503709711756, 0.006111328531002826, 0.006106324189155089, 0.006101490684168547, 0.006096828016043198, 0.006092336184779044, 0.006088015190376083, 0.006083865032834317, 0.006079885712153745, 0.006076077228334366, 0.006072439581376182, 0.006068972771279192, 0.006065676798043397, 0.006062551661668795, 0.006059597362155387, 0.006056813899503174, 0.006054201273712154, 0.006051759484782328, 0.0060494885327136965, 0.006047388417506259, 0.0060454591391600155, 0.006043700697674966, 0.006042113093051111, 0.00604069632528845, 0.006039450394386982, 0.00603837530034671, 0.006037471043167631, 0.006036737622849746, 0.006036175039393055, 0.006035783292797558, 0.006035562383063256, 0.006035512310190147, 0.0060356330741782325, 0.006035924675027512, 0.0060363871127379854, 0.006037020387309654, 0.006037824498742515, 0.006038799447036571, 0.006039945232191821, 0.006041261854208265, 0.006042749313085903, 0.006044407608824735, 0.006046236741424761, 0.006048236710885981, 0.006050407517208396, 0.006052749160392004, 0.006055261640436806, 0.006057944957342803, 0.006060799111109993, 0.006063824101738378, 0.006067019929227957, 0.006070386593578729, 0.006073924094790696, 0.006077632432863857, 0.006081511607798212, 0.0060855616195937615, 0.0060897824682505045, 0.0060941741537684415, 0.006098736676147572, 0.006103470035387898, 0.006108374231489418, 0.006113449264452131, 0.006118695134276039, 0.00612411184096114, 0.006129699384507435, 0.006135457764914925, 0.006141386982183609]<!--profile drag coefficient for fuselage w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
+          <CnBeta is_input="False">-0.10154900016098346<!--derivative of yawing moment against sideslip angle for fuselage in cruise conditions--></CnBeta>
         </cruise>
       </fuselage>
       <high_lift_devices>
         <landing>
           <CD is_input="False">0.03309219200000092<!--increment of CD due to high-lift devices for landing phase--></CD>
-          <CL is_input="False">1.218000778714024<!--increment of CL due to high-lift devices for landing phase--></CL>
+          <CL is_input="False">1.218000778714029<!--increment of CL due to high-lift devices for landing phase--></CL>
         </landing>
       </high_lift_devices>
       <horizontal_tail>
         <cruise>
-          <CD0 is_input="False">0.0017542856255862048<!--profile drag coefficient for horizontal tail in cruise conditions--></CD0>
+          <CD0 is_input="False">0.0017542856255812595<!--profile drag coefficient for horizontal tail in cruise conditions--></CD0>
           <CL_alpha units="1/rad" is_input="False">3.4698175649817595<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in cruise conditions--></CL_alpha>
         </cruise>
       </horizontal_tail>
       <nacelles>
         <cruise>
-          <CD0 is_input="False">0.0015494146574837723<!--profile drag coefficient for nacelles in cruise conditions--></CD0>
+          <CD0 is_input="False">0.0015494146574863315<!--profile drag coefficient for nacelles in cruise conditions--></CD0>
         </cruise>
       </nacelles>
       <pylons>
         <cruise>
-          <CD0 is_input="False">0.0003279580607410157<!--profile drag coefficient for pylons in cruise conditions--></CD0>
+          <CD0 is_input="False">0.00032795806074174594<!--profile drag coefficient for pylons in cruise conditions--></CD0>
         </cruise>
       </pylons>
       <vertical_tail>
         <cruise>
-          <CD0 is_input="False">0.0013127123388374106<!--profile drag coefficient for vertical tail in cruise conditions--></CD0>
+          <CD0 is_input="False">0.0013127123388340998<!--profile drag coefficient for vertical tail in cruise conditions--></CD0>
           <CL_alpha units="1/rad" is_input="False">2.546156443275808<!--derivative of lift coefficient of horizontal tail with respect to local "angle of attack" in cruise conditions--></CL_alpha>
-          <CnBeta units="m**2" is_input="False">0.2419957361606443<!--derivative of yawing moment against sideslip angle for vertical tail in cruise conditions--></CnBeta>
+          <CnBeta units="m**2" is_input="False">0.24199573616098347<!--derivative of yawing moment against sideslip angle for vertical tail in cruise conditions--></CnBeta>
         </cruise>
       </vertical_tail>
       <wing>
         <cruise>
-          <CD0 is_input="False">[0.005708745873376808, 0.005721422587582233, 0.005732603140793926, 0.005742377084218863, 0.005750833969064022, 0.005758063346536382, 0.005764154767842921, 0.0057691977841906154, 0.0057732819467864425, 0.005776496806837382, 0.005778931915550413, 0.005780676824132511, 0.005781821083790655, 0.005782454245731822, 0.005782665861162992, 0.0057825454812911415, 0.005782182657323248, 0.005781666940466291, 0.005781087881927248, 0.005780535032913095, 0.0057800979446308125, 0.005779866168287377, 0.005779929255089767, 0.005780376756244959, 0.005781298222959934, 0.005782783206441666, 0.005784921257897138, 0.005787801928533322, 0.005791514769557201, 0.005796149332175752, 0.0058017951675959495, 0.005808541827024774, 0.005816478861669205, 0.005825695822736217, 0.005836282261432791, 0.0058483277289659045, 0.005861921776542532, 0.005877153955369655, 0.0058941138166542515, 0.005912890911603297, 0.0059335747914237725, 0.005956255007322653, 0.005981021110506918, 0.006007962652183545, 0.006037169183559513, 0.006068730255841799, 0.006102735420237379, 0.006139274227953236, 0.006178436230196344, 0.006220310978173681, 0.006264988023092227, 0.006312556916158957, 0.006363107208580851, 0.006416728451564887, 0.006473510196318045, 0.006533541994047297, 0.0065969133959596265, 0.00666371395326201, 0.006734033217161424, 0.006807960738864846, 0.006885586069579258, 0.006966998760511633, 0.007052288362868952, 0.007141544427858191, 0.0072348565066863305, 0.007332314150560347, 0.007434006910687219, 0.007540024338273923, 0.007650455984527439, 0.007765391400654743, 0.007884920137862813, 0.008009131747358627, 0.008138115780349165, 0.008271961788041404, 0.00841075932164232, 0.008554597932358894, 0.008703567171398103, 0.008857756589966922, 0.009017255739272333, 0.009182154170521314, 0.009352541434920838, 0.009528507083677888, 0.00971014066799944, 0.009897531739092472, 0.010090769848163959, 0.010289944546420885, 0.010495145385070223, 0.010706461915318953, 0.010923983688374056, 0.011147800255442505, 0.011378001167731279, 0.011614675976447357, 0.01185791423279772, 0.012107805487989337, 0.012364439293229198, 0.012627905199724263, 0.012898292758681531, 0.013175691521307965, 0.013460191038810552, 0.013751880862396267, 0.014050850543272085, 0.014357189632644981, 0.014670987681721946, 0.014992334241709948, 0.015321318863815965, 0.015658031099246975, 0.016002560499209964, 0.016354996614911906, 0.016715428997559775, 0.017083947198360535, 0.01746064076852119, 0.01784559925924872, 0.018238912221750076, 0.01864066920723226, 0.019050959766902225, 0.019469873451966973, 0.019897499813633472, 0.0203339284031087, 0.02077924877159964, 0.021233550470313268, 0.021696923050456562, 0.022169456063236486, 0.02265123905986004, 0.023142361591534193, 0.023642913209465922, 0.024152983464862204, 0.024672661908930003, 0.025202038092876328, 0.025741201567908135, 0.026290241885232418, 0.026849248596056124, 0.027418311251586266, 0.02799751940302981, 0.028586962601593727, 0.029186730398485, 0.029796912344910605, 0.030417597992077525, 0.031048876891192727, 0.0316908385934632, 0.03234357265009592, 0.033007168612297855, 0.03368171603127599, 0.0343673044582373, 0.03506402344438879, 0.035771962540937396, 0.036491211299090116, 0.03722185927005392, 0.037963996005035805, 0.038717711055242736, 0.039483093971881704]<!--profile drag coefficient for wing w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
+          <CD0 is_input="False">[0.005708745873376521, 0.005721422587581946, 0.005732603140793638, 0.005742377084218576, 0.005750833969063734, 0.005758063346536092, 0.005764154767842631, 0.005769197784190325, 0.005773281946786154, 0.0057764968068370936, 0.005778931915550123, 0.005780676824132221, 0.005781821083790365, 0.005782454245731533, 0.005782665861162702, 0.005782545481290852, 0.005782182657322958, 0.0057816669404660015, 0.005781087881926958, 0.005780535032912804, 0.005780097944630523, 0.005779866168287086, 0.005779929255089476, 0.005780376756244669, 0.005781298222959643, 0.005782783206441377, 0.005784921257896847, 0.005787801928533032, 0.005791514769556911, 0.00579614933217546, 0.005801795167595658, 0.005808541827024483, 0.005816478861668913, 0.005825695822735926, 0.005836282261432499, 0.0058483277289656105, 0.0058619217765422385, 0.005877153955369361, 0.005894113816653956, 0.005912890911603001, 0.005933574791423474, 0.005956255007322353, 0.005981021110506617, 0.0060079626521832435, 0.00603716918355921, 0.006068730255841494, 0.006102735420237073, 0.006139274227952928, 0.006178436230196033, 0.0062203109781733676, 0.006264988023091912, 0.006312556916158641, 0.006363107208580533, 0.006416728451564566, 0.00647351019631772, 0.00653354199404697, 0.006596913395959297, 0.006663713953261675, 0.006734033217161086, 0.006807960738864504, 0.006885586069578912, 0.006966998760511283, 0.007052288362868598, 0.007141544427857832, 0.007234856506685968, 0.007332314150559979, 0.007434006910686845, 0.007540024338273545, 0.007650455984527056, 0.007765391400654352, 0.007884920137862416, 0.008009131747358225, 0.008138115780348754, 0.00827196178804099, 0.0084107593216419, 0.008554597932358464, 0.008703567171397664, 0.008857756589966478, 0.00901725573927188, 0.00918215417052085, 0.00935254143492037, 0.00952850708367741, 0.009710140667998952, 0.009897531739091976, 0.010090769848163452, 0.01028994454642037, 0.010495145385069697, 0.010706461915318417, 0.010923983688373507, 0.011147800255441945, 0.01137800116773071, 0.011614675976446772, 0.011857914232797123, 0.012107805487988729, 0.012364439293228575, 0.012627905199723628, 0.012898292758680884, 0.013175691521307304, 0.013460191038809875, 0.013751880862395576, 0.01405085054327138, 0.01435718963264426, 0.01467098768172121, 0.014992334241709194, 0.015321318863815199, 0.01565803109924619, 0.01600256049920916, 0.016354996614911087, 0.016715428997558932, 0.01708394719835968, 0.017460640768520316, 0.01784559925924782, 0.018238912221749157, 0.018640669207231324, 0.01905095976690127, 0.019469873451965998, 0.019897499813632473, 0.020333928403107677, 0.020779248771598594, 0.021233550470312206, 0.021696923050455473, 0.022169456063235372, 0.0226512390598589, 0.02314236159153303, 0.023642913209464732, 0.02415298346486099, 0.024672661908928764, 0.025202038092875065, 0.02574120156790685, 0.026290241885231096, 0.026849248596054774, 0.027418311251584893, 0.027997519403028404, 0.028586962601592287, 0.02918673039848354, 0.029796912344909107, 0.030417597992076002, 0.031048876891191176, 0.031690838593461605, 0.0323435726500943, 0.0330071686122962, 0.0336817160312743, 0.034367304458235576, 0.03506402344438702, 0.03577196254093559, 0.03649121129908829, 0.03722185927005205, 0.037963996005033904, 0.0387177110552408, 0.039483093971879726]<!--profile drag coefficient for wing w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
           <reynolds is_input="False">6124998.624249204<!--Reynolds number based on wing mean aerodynamic chord in cruise conditions--></reynolds>
         </cruise>
         <landing>
-          <reynolds is_input="False">18164483.56108458<!--Reynolds number based on wing mean aerodynamic chord in landing conditions--></reynolds>
+          <reynolds is_input="False">18164483.56106389<!--Reynolds number based on wing mean aerodynamic chord in landing conditions--></reynolds>
         </landing>
       </wing>
     </aerodynamics>

--- a/tests/integration_tests/oad_process/data/no_kink_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/no_kink_breguet_result.xml
@@ -1,6 +1,6 @@
 <!--
   ~ This file is part of FAST-OAD_CS25
-  ~ Copyright (C) 2022 ONERA & ISAE-SUPAERO
+  ~ Copyright (C) 2024 ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
@@ -14,1704 +14,1005 @@
   -->
 
 <FASTOAD_model>
-    <data>
-        <TLAR>
-            <NPAX is_input="True">
-                150.0<!--top-level requirement: number of passengers, assuming a classic eco/business class repartition--></NPAX>
-            <approach_speed units="knot" is_input="True">
-                132.0<!--top-level requirement: approach speed--></approach_speed>
-            <cruise_mach is_input="True">0.78<!--Input defined by the mission.--></cruise_mach>
-            <range units="nmi" is_input="True">2750.0<!--Input defined by the mission.--></range>
-        </TLAR>
-        <geometry>
-            <has_T_tail is_input="True">
-                0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
-            <aircraft>
-                <wetted_area units="m**2" is_input="False">
-                    810.3205218165627<!--total wetted area--></wetted_area>
-            </aircraft>
-            <cabin>
-                <NPAX1 is_input="False">
-                    157.0<!--number of passengers if there are only economical class seats--></NPAX1>
-                <aisle_width units="m" is_input="True">0.48<!--width of aisles--></aisle_width>
-                <exit_width units="m" is_input="True">0.51<!--width of exits--></exit_width>
-                <length units="m" is_input="False">30.380964840000004<!--cabin length--></length>
-                <containers>
-                    <count_by_row is_input="True">
-                        1.0<!--number of cargo containers along width--></count_by_row>
-                </containers>
-                <crew_count>
-                    <commercial is_input="False">
-                        4.0<!--number of commercial crew members--></commercial>
-                    <technical is_input="True">
-                        2.0<!--number of technical crew members--></technical>
-                </crew_count>
-                <seats>
-                    <economical>
-                        <count_by_row is_input="True">
-                            6.0<!--number of economical class seats along width--></count_by_row>
-                        <length units="m" is_input="True">
-                            0.86<!--length of economical class seats--></length>
-                        <width units="m" is_input="True">
-                            0.46<!--width of economical class seats--></width>
-                    </economical>
-                </seats>
-            </cabin>
-            <flap>
-                <chord_ratio is_input="True">
-                    0.197<!--mean value of (flap chord)/(section chord)--></chord_ratio>
-                <span_ratio is_input="True">
-                    0.8<!--ratio (width of flaps)/(total span)--></span_ratio>
-            </flap>
-            <fuselage>
-                <PAX_length units="m" is_input="False">
-                    22.87<!--length of passenger-dedicated zone--></PAX_length>
-                <front_length units="m" is_input="False">
-                    6.901795999999999<!--length of front non-cylindrical part of the fuselage--></front_length>
-                <length units="m" is_input="False">37.507364<!--total fuselage length--></length>
-                <maximum_height units="m" is_input="False">
-                    4.05988<!--maximum fuselage height--></maximum_height>
-                <maximum_width units="m" is_input="False">
-                    3.91988<!--maximum fuselage width--></maximum_width>
-                <rear_length units="m" is_input="False">
-                    14.615568<!--length of rear non-cylindrical part of the fuselage--></rear_length>
-                <wetted_area units="m**2" is_input="False">
-                    401.95600094323777<!--wetted area of fuselage--></wetted_area>
-            </fuselage>
-            <horizontal_tail>
-                <area units="m**2" is_input="False">
-                    34.515477556468596<!--horizontal tail area--></area>
-                <aspect_ratio is_input="True">
-                    4.28778048454<!--aspect ratio of horizontal tail--></aspect_ratio>
-                <span units="m" is_input="False">12.16531096876299<!--horizontal tail span--></span>
-                <sweep_0 units="deg" is_input="False">
-                    33.31651496553977<!--sweep angle at leading edge of horizontal tail--></sweep_0>
-                <sweep_100 units="deg" is_input="False">
-                    8.808941784256668<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
-                <sweep_25 units="deg" is_input="True">
-                    28.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
-                <taper_ratio is_input="True">0.3<!--taper ratio of horizontal tail--></taper_ratio>
-                <thickness_ratio is_input="True">
-                    0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
-                <wetted_area units="m**2" is_input="False">
-                    69.03095511293719<!--wetted area of horizontal tail--></wetted_area>
-                <MAC>
-                    <length units="m" is_input="False">
-                        3.1114118668661477<!--mean aerodynamic chord length of horizontal tail--></length>
-                    <y units="m" is_input="False">
-                        2.4954484038488185<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
-                    <at25percent>
-                        <x>
-                            <from_wingMAC25 units="m" is_input="False">
-                                17.524905240000006<!--distance along X between 25% MAC of wing and 25% MAC of horizontal tail--></from_wingMAC25>
-                            <local units="m" is_input="False">
-                                1.6402330650411152<!--X-position of the 25% of mean aerodynamic chord of horizontal tail w.r.t. leading edge of center chord--></local>
-                        </x>
-                    </at25percent>
-                </MAC>
-                <center>
-                    <chord units="m" is_input="False">
-                        4.36493031682661<!--chord length at center of horizontal tail--></chord>
-                </center>
-                <tip>
-                    <chord units="m" is_input="False">
-                        1.3094790950479829<!--chord length at tip of horizontal tail--></chord>
-                </tip>
-            </horizontal_tail>
-            <landing_gear>
-                <height units="m" is_input="False">
-                    3.0411414104151127<!--height of landing gear--></height>
-            </landing_gear>
-            <propulsion>
-                <layout is_input="True">
-                    1.0<!--position of engines (1=under the wing / 2=rear fuselage)--></layout>
-                <engine>
-                    <count is_input="True">2.0<!--number of engines--></count>
-                    <y_ratio is_input="True">
-                        0.34<!--engine position with respect to total span--></y_ratio>
-                </engine>
-                <fan>
-                    <length units="m" is_input="False">
-                        3.1268896238914476<!--engine length--></length>
-                </fan>
-                <nacelle>
-                    <diameter units="m" is_input="False">
-                        2.1722438645822235<!--nacelle diameter--></diameter>
-                    <length units="m" is_input="False">
-                        5.2114827064857465<!--nacelle length--></length>
-                    <wetted_area units="m**2" is_input="False">
-                        21.6092<!--wetted area of nacelle--></wetted_area>
-                    <y units="m" is_input="False">
-                        6.003405073972711<!--Y-position of nacelle center--></y>
-                </nacelle>
-                <pylon>
-                    <length units="m" is_input="False">5.732630977134321<!--pylon length--></length>
-                    <wetted_area units="m**2" is_input="False">
-                        7.56322<!--wetted area of pylon--></wetted_area>
-                </pylon>
-            </propulsion>
-            <slat>
-                <chord_ratio is_input="True">
-                    0.177<!--mean value of slat chord)/(section chord)--></chord_ratio>
-                <span_ratio is_input="True">
-                    0.9<!--ratio (width of slats)/(total span)--></span_ratio>
-            </slat>
-            <vertical_tail>
-                <area units="m**2" is_input="False">
-                    27.716207520741502<!--vertical tail area--></area>
-                <aspect_ratio is_input="True">
-                    1.74462618632<!--aspect ratio of vertical tail--></aspect_ratio>
-                <span units="m" is_input="False">6.95373434849084<!--vertical tail span--></span>
-                <sweep_0 units="deg" is_input="False">
-                    40.51480176597914<!--sweep angle at leading edge of vertical tail--></sweep_0>
-                <sweep_100 units="deg" is_input="False">
-                    13.34651978540079<!--sweep angle at trailing edge of vertical tail--></sweep_100>
-                <sweep_25 units="deg" is_input="True">
-                    35.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
-                <taper_ratio is_input="True">0.3<!--taper ratio of vertical tail--></taper_ratio>
-                <thickness_ratio is_input="True">
-                    0.1<!--thickness ratio of vertical tail--></thickness_ratio>
-                <wetted_area units="m**2" is_input="False">
-                    58.20403579355716<!--wetted area of vertical tail--></wetted_area>
-                <MAC>
-                    <length units="m" is_input="False">
-                        4.371017455840588<!--mean aerodynamic chord length of vertical tail--></length>
-                    <z units="m" is_input="False">
-                        2.8528140916885496<!--Z-position of mean aerodynamic chord of vertical tail--></z>
-                    <at25percent>
-                        <x>
-                            <from_wingMAC25 units="m" is_input="False">
-                                16.399684320000002<!--distance along X between 25% MAC of wing and 25% MAC of vertical tail--></from_wingMAC25>
-                            <local units="m" is_input="False">
-                                2.437808294569973<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. leading edge of root chord--></local>
-                        </x>
-                    </at25percent>
-                </MAC>
-                <root>
-                    <chord units="m" is_input="False">
-                        6.1320029056756455<!--chord length at root of vertical tail--></chord>
-                </root>
-                <tip>
-                    <chord units="m" is_input="False">
-                        1.8396008717026935<!--chord length at tip of vertical tail--></chord>
-                </tip>
-            </vertical_tail>
-            <wing>
-                <area units="m**2" is_input="False">
-                    131.54947400983872<!--wing reference area--></area>
-                <aspect_ratio is_input="True">9.48<!--wing aspect ratio--></aspect_ratio>
-                <b_50 units="m" is_input="False">
-                    38.24158104508373<!--actual length between root and tip along 50% of chord--></b_50>
-                <outer_area units="m**2" is_input="False">
-                    111.39234503225714<!--wing area outside of fuselage--></outer_area>
-                <span units="m" is_input="False">35.31414749395712<!--wing span--></span>
-                <sweep_0 units="deg" is_input="False">
-                    27.34279222801918<!--sweep angle at leading edge of wing--></sweep_0>
-                <sweep_100_inner units="deg" is_input="False">
-                    17.43106751948086<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
-                <sweep_100_outer units="deg" is_input="False">
-                    17.43106751948086<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
-                <sweep_25 units="deg" is_input="True">
-                    25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-                <taper_ratio is_input="False">0.38<!--taper ratio of wing--></taper_ratio>
-                <thickness_ratio is_input="False">
-                    0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
-                <virtual_taper_ratio is_input="True">
-                    0.38<!--taper ratio of wing computed from virtual root chord--></virtual_taper_ratio>
-                <wetted_area units="m**2" is_input="False">
-                    222.78469006451428<!--wetted area of wing--></wetted_area>
-                <MAC>
-                    <length units="m" is_input="False">
-                        3.9945880458385252<!--length of mean aerodynamic chord of wing--></length>
-                    <y units="m" is_input="False">
-                        7.460437278492227<!--Y-position of mean aerodynamic chord of wing--></y>
-                    <at25percent>
-                        <x units="m" is_input="True">
-                            16.606796<!--X-position of the 25% of mean aerodynamic chord of wing w.r.t. aircraft nose (drives position of wing along fuselage)--></x>
-                    </at25percent>
-                    <leading_edge>
-                        <x>
-                            <local units="m" is_input="False">
-                                2.9218679777999474<!--X-position of leading edge of mean aerodynamic chord w.r.t. leading edge of root chord--></local>
-                        </x>
-                    </leading_edge>
-                </MAC>
-                <kink>
-                    <chord units="m" is_input="False">
-                        5.1422821455300385<!--chord length at wing kink--></chord>
-                    <span_ratio is_input="True">
-                        0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
-                    <thickness_ratio is_input="False">
-                        0.15921402692414266<!--thickness ratio at wing kink--></thickness_ratio>
-                    <y units="m" is_input="False">1.95994<!--Y-position of wing kink--></y>
-                    <leading_edge>
-                        <x>
-                            <local units="m" is_input="False">
-                                0.0<!--X-position of leading edge at wing kink w.r.t. leading edge of root chord--></local>
-                        </x>
-                    </leading_edge>
-                </kink>
-                <root>
-                    <chord units="m" is_input="False">
-                        5.1422821455300385<!--chord length at wing root--></chord>
-                    <thickness_ratio is_input="False">
-                        0.15921402692414266<!--thickness ratio at wing root--></thickness_ratio>
-                    <virtual_chord units="m" is_input="False">
-                        5.1422821455300385<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
-                    <y units="m" is_input="False">1.95994<!--Y-position of wing root--></y>
-                </root>
-                <tip>
-                    <chord units="m" is_input="False">
-                        1.9540672153014147<!--chord length at wing tip--></chord>
-                    <thickness_ratio is_input="False">
-                        0.11042263157642153<!--thickness ratio at wing tip--></thickness_ratio>
-                    <y units="m" is_input="False">17.65707374697856<!--Y-position of wing tip--></y>
-                    <leading_edge>
-                        <x>
-                            <local units="m" is_input="False">
-                                8.116747409856528<!--X-position of leading edge at wing tip w.r.t. leading edge of root chord--></local>
-                        </x>
-                    </leading_edge>
-                </tip>
-                <spar_ratio>
-                    <front>
-                        <kink is_input="True">
-                            0.15<!--ratio (front spar position)/(chord length) at wing kink--></kink>
-                        <root is_input="True">
-                            0.11<!--ratio (front spar position)/(chord length) at wing root--></root>
-                        <tip is_input="True">
-                            0.27<!--ratio (front spar position)/(chord length) at wing tip--></tip>
-                    </front>
-                    <rear>
-                        <kink is_input="True">
-                            0.66<!--ratio (rear spar position)/(chord length) at wing kink--></kink>
-                        <root is_input="True">
-                            0.57<!--ratio (rear spar position)/(chord length) at wing root--></root>
-                        <tip is_input="True">
-                            0.56<!--ratio (rear spar position)/(chord length) at wing tip--></tip>
-                    </rear>
-                </spar_ratio>
-            </wing>
-        </geometry>
-        <handling_qualities>
-            <static_margin is_input="False">
-                0.027597511861297774<!--(X-position of neutral point - X-position of center of gravity ) / (mean aerodynamic chord)--></static_margin>
-        </handling_qualities>
-        <propulsion>
-            <MTO_thrust units="N" is_input="True">
-                117880.0<!--maximum thrust of one engine at sea level--></MTO_thrust>
-            <rubber_engine>
-                <bypass_ratio is_input="True">
-                    4.9<!--bypass ratio for rubber engine model--></bypass_ratio>
-                <delta_t4_climb is_input="True">
-                    0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_climb>
-                <delta_t4_cruise is_input="True">
-                    0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_cruise>
-                <design_altitude units="m" is_input="True">
-                    10058.4<!--design altitude for rubber engine model--></design_altitude>
-                <maximum_mach is_input="True">
-                    0.85<!--maximum Mach number for rubber engine model--></maximum_mach>
-                <overall_pressure_ratio is_input="True">
-                    32.6<!--Overall pressure ratio for rubber engine model--></overall_pressure_ratio>
-                <turbine_inlet_temperature units="degK" is_input="True">
-                    1633.0<!--design turbine inlet temperature (T4) for rubber engine model--></turbine_inlet_temperature>
-            </rubber_engine>
-        </propulsion>
-        <load_case>
-            <gust_intensity>0.0</gust_intensity>
-            <lc1>
-                <U_gust units="m/s" is_input="True">
-                    15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
-                <Vc_EAS units="m/s" is_input="True">
-                    375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
-                <altitude units="m" is_input="True">
-                    20000.0<!--altitude for sizing load case 1 (gust with minimum aircraft mass)--></altitude>
-            </lc1>
-            <lc2>
-                <U_gust units="m/s" is_input="True">
-                    15.25<!--gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)--></U_gust>
-                <Vc_EAS units="m/s" is_input="True">
-                    375.0<!--equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)--></Vc_EAS>
-                <altitude units="m" is_input="True">
-                    20000.0<!--altitude for sizing load case 2 (gust with maximum aircraft mass)--></altitude>
-            </lc2>
-        </load_case>
-        <mission>
-            <sizing>
-                <TOW units="kg" is_input="False">
-                    78078.16265106136<!--TakeOff Weight for mission "sizing"--></TOW>
-                <ZFW units="kg" is_input="False">
-                    57306.14369066358<!--Zero Fuel Weight for mission "sizing"--></ZFW>
-                <block_fuel units="kg" is_input="False">
-                    20772.018960397778<!--Loaded fuel before taxi-out for mission "sizing"--></block_fuel>
-                <distance units="m" is_input="False">
-                    5093000.0<!--covered ground distance during mission "sizing"--></distance>
-                <duration units="s" is_input="False">
-                    19857.45794460585<!--duration of mission "sizing"--></duration>
-                <fuel units="kg" is_input="False">
-                    20772.018969366334<!--burned fuel during mission "sizing"--></fuel>
-                <needed_block_fuel units="kg" is_input="False">
-                    20772.018969366334<!--Needed fuel to complete mission "sizing", including reserve fuel--></needed_block_fuel>
-                <needed_onboard_fuel_at_takeoff units="kg" is_input="False">
-                    20772.018969366334<!--fuel quantity at instant of takeoff of mission "sizing"--></needed_onboard_fuel_at_takeoff>
-                <onboard_fuel_at_takeoff units="kg" is_input="False">
-                    20772.018969366334<!--TakeOff Weight for mission "sizing"_inp_data:mission:sizing:onboard_fuel_at_takeoff--></onboard_fuel_at_takeoff>
-                <cs25>
-                    <sizing_load_1 units="kg" is_input="False">
-                        249267.94078198788<!--sizing load during gust with minimum aircraft mass--></sizing_load_1>
-                    <sizing_load_2 units="kg" is_input="False">
-                        262325.82076931436<!--sizing load during gust with maximum aircraft mass--></sizing_load_2>
-                </cs25>
-                <landing>
-                    <flap_angle units="deg" is_input="True">
-                        30.0<!--flap angle during landing phase in sizing mission--></flap_angle>
-                    <slat_angle units="deg" is_input="True">
-                        20.0<!--slat angle during landing phase in sizing mission--></slat_angle>
-                </landing>
-                <main_route>
-                    <distance units="m" is_input="False">
-                        5093000.0<!--covered ground distance during route "main_route" in mission "sizing"--></distance>
-                    <duration units="s" is_input="False">
-                        19857.45794460585<!--duration of route "main_route" in mission "sizing"--></duration>
-                    <fuel units="kg" is_input="False">
-                        17333.65034846463<!--burned fuel during route "main_route" in mission "sizing"--></fuel>
-                    <climb>
-                        <distance units="m" is_input="False">
-                            250000.0<!--covered ground distance during phase "climb" of route "main_route" in mission "sizing"--></distance>
-                        <duration units="s" is_input="False">
-                            0.0<!--duration of phase "climb" of route "main_route" in mission "sizing"--></duration>
-                        <fuel units="kg" is_input="False">
-                            2342.34487953184<!--burned fuel during phase "climb" of route "main_route" in mission "sizing"--></fuel>
-                    </climb>
-                    <cruise>
-                        <altitude units="ft" is_input="True">
-                            35000.0<!--Input defined by the mission.--></altitude>
-                        <distance units="m" is_input="False">
-                            4593000.0<!--covered ground distance during phase "cruise" of route "main_route" in mission "sizing"--></distance>
-                        <duration units="s" is_input="False">
-                            19857.45794460585<!--duration of phase "cruise" of route "main_route" in mission "sizing"--></duration>
-                        <fuel units="kg" is_input="False">
-                            13751.62154439<!--burned fuel during phase "cruise" of route "main_route" in mission "sizing"--></fuel>
-                    </cruise>
-                    <descent>
-                        <distance units="m" is_input="False">
-                            250000.0<!--covered ground distance during phase "descent" of route "main_route" in mission "sizing"--></distance>
-                        <duration units="s" is_input="False">
-                            0.0<!--duration of phase "descent" of route "main_route" in mission "sizing"--></duration>
-                        <fuel units="kg" is_input="False">
-                            1239.683924542791<!--burned fuel during phase "descent" of route "main_route" in mission "sizing"--></fuel>
-                    </descent>
-                </main_route>
-                <reserve>
-                    <distance units="m" is_input="False">
-                        0.0<!--covered ground distance during phase "reserve" in mission "sizing"--></distance>
-                    <duration units="s" is_input="False">
-                        0.0<!--duration of phase "reserve" in mission "sizing"--></duration>
-                    <fuel units="kg" is_input="False">
-                        0.0<!--burned fuel during phase "reserve" in mission "sizing"--></fuel>
-                </reserve>
-                <takeoff>
-                    <duration units="min" is_input="True">
-                        0.0<!--Input defined by the mission.--></duration>
-                    <V2 units="m/s" is_input="True">
-                        0.0<!--takeoff safety speed for mission "sizing"--></V2>
-                    <altitude units="m" is_input="True">
-                        0.0<!--altitude of airport for mission "sizing"--></altitude>
-                    <fuel units="kg" is_input="True">
-                        0.0<!--burned fuel during takeoff phase of mission "sizing"--></fuel>
-                </takeoff>
-                <taxi_out>
-                    <distance units="m" is_input="False">
-                        0.0<!--distance during taxi-out of mission "sizing"--></distance>
-                    <duration units="s" is_input="True">
-                        0.0<!--duration of taxi-out in mission "sizing"--></duration>
-                    <fuel units="kg" is_input="False">
-                        0.0<!--burned fuel during taxi-out of mission "sizing"--></fuel>
-                    <thrust_rate is_input="True">
-                        0.0<!--thrust rate during taxi-out in mission "sizing"--></thrust_rate>
-                </taxi_out>
-            </sizing>
-        </mission>
-        <weight>
-            <aircraft>
-                <MFW units="kg" is_input="False">20772.01896039777<!--maximum fuel weight--></MFW>
-                <MLW units="kg" is_input="False">67104.5123121034<!--maximum landing weight--></MLW>
-                <MTOW units="kg" is_input="False">
-                    78078.16265106136<!--maximum takeoff weight--></MTOW>
-                <MZFW units="kg" is_input="False">
-                    63306.14369066358<!--maximum zero fuel weight--></MZFW>
-                <OWE units="kg" is_input="False">43698.14369066358<!--Mass of crew--></OWE>
-                <additional_fuel_capacity units="kg" is_input="False">
-                    -8.567261829739437e-06<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
-                <max_payload units="kg" is_input="False">
-                    19608.0<!--max payload weight--></max_payload>
-                <payload units="kg" is_input="False">
-                    13608.0<!--_inp_data:weight:aircraft:payload--></payload>
-                <sizing_block_fuel units="kg" is_input="False">
-                    20772.018969366334<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>
-                <sizing_onboard_fuel_at_takeoff units="kg" is_input="False">
-                    20772.018969366334<!--_inp_data:weight:aircraft:sizing_onboard_fuel_at_takeoff--></sizing_onboard_fuel_at_takeoff>
-                <CG>
-                    <aft>
-                        <MAC_position is_input="False">
-                            0.3908940302020053<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
-                        <x units="m" is_input="False">
-                            17.16960960877494<!--most aft X-position of aircraft center of gravity--></x>
-                    </aft>
-                </CG>
-                <empty>
-                    <CG>
-                        <MAC_position is_input="False">
-                            0.3397794165834335<!--X-position of center of gravity as ratio of mean aerodynamic chord for empty aircraft--></MAC_position>
-                    </CG>
-                </empty>
-                <load_cases>
-                    <CG>
-                        <MAC_position is_input="False">[[0.32081603514936613], [0.2421850583784403],
-                            [0.3408940302020053], [0.3375195693979701]]
-                            <maximum is_input="False">0.3408940302020053</maximum>
-                        </MAC_position>
-                    </CG>
-                </load_cases>
-            </aircraft>
-            <aircraft_empty>
-                <mass units="kg" is_input="False">
-                    43228.14367229583<!--mass of empty aircraft (=OWE - mass of crew)--></mass>
-                <CG>
-                    <x units="m" is_input="False">
-                        16.96542778424654<!--X-position center of gravity of empty aircraft--></x>
-                </CG>
-            </aircraft_empty>
-            <airframe>
-                <mass units="kg" is_input="False">24439.862074911904<!--Mass of airframe--></mass>
-                <flight_controls>
-                    <mass units="kg" is_input="False">
-                        779.66668605174<!--Mass of airframe_inp_data:weight:airframe:flight_controls:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            19.555590518598432<!--flight controls (A4): X-position of center of gravity--></x>
-                    </CG>
-                </flight_controls>
-                <fuselage>
-                    <mass units="kg" is_input="False">
-                        8896.047233717161<!--Mass of airframe_inp_data:weight:airframe:fuselage:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            16.8783138<!--fuselage (A2): X-position of center of gravity--></x>
-                    </CG>
-                </fuselage>
-                <horizontal_tail>
-                    <mass units="kg" is_input="False">
-                        736.2113713995354<!--Mass of airframe_inp_data:weight:airframe:horizontal_tail:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            34.57850180280799<!--horizontal tail (A31): X-position of center of gravity--></x>
-                    </CG>
-                </horizontal_tail>
-                <paint>
-                    <mass units="kg" is_input="False">
-                        145.85769392698128<!--Mass of airframe_inp_data:weight:airframe:paint:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            0.0<!--paint (A7): X-position of center of gravity--></x>
-                    </CG>
-                </paint>
-                <pylon>
-                    <mass units="kg" is_input="False">
-                        1211.8837953053956<!--Mass of airframe_inp_data:weight:airframe:pylon:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            13.518747237993832<!--pylon (A6): X-position of center of gravity--></x>
-                    </CG>
-                </pylon>
-                <vertical_tail>
-                    <mass units="kg" is_input="False">
-                        583.3894138188518<!--Mass of airframe_inp_data:weight:airframe:vertical_tail:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            34.328000756913774<!--vertical tail (A32): X-position of center of gravity--></x>
-                    </CG>
-                </vertical_tail>
-                <wing>
-                    <mass units="kg" is_input="False">
-                        9488.446147925457<!--Mass of airframe_inp_data:weight:airframe:wing:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            16.40496219224192<!--wing (A1): X-position of center of gravity--></x>
-                    </CG>
-                </wing>
-                <landing_gear>
-                    <front>
-                        <mass units="kg" is_input="False">
-                            388.37112897010985<!--Mass of airframe_inp_data:weight:airframe:landing_gear:front:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                5.176347<!--front landing gear (A52): X-position of center of gravity--></x>
-                        </CG>
-                    </front>
-                    <main>
-                        <mass units="kg" is_input="False">
-                            2209.9886037966735<!--Mass of airframe_inp_data:weight:airframe:landing_gear:main:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                18.212502009537978<!--main landing gear (A51): X-position of center of gravity--></x>
-                        </CG>
-                    </main>
-                </landing_gear>
-            </airframe>
-            <crew>
-                <mass units="kg" is_input="False">
-                    470.0<!--Mass of crew_inp_data:weight:crew:mass--></mass>
-            </crew>
-            <furniture>
-                <mass units="kg" is_input="False">3112.5<!--Mass of aircraft furniture--></mass>
-                <food_water>
-                    <mass units="kg" is_input="False">
-                        1312.5<!--Mass of aircraft furniture_inp_data:weight:furniture:food_water:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            29.403796000000007<!--food water (D3): X-position of center of gravity--></x>
-                    </CG>
-                </food_water>
-                <passenger_seats>
-                    <mass units="kg" is_input="False">
-                        1500.0<!--Mass of aircraft furniture_inp_data:weight:furniture:passenger_seats:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            16.616796<!--passenger seats (D2): X-position of center of gravity--></x>
-                    </CG>
-                </passenger_seats>
-                <security_kit>
-                    <mass units="kg" is_input="False">
-                        225.0<!--Mass of aircraft furniture_inp_data:weight:furniture:security_kit:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            16.616796<!--security kit (D4): X-position of center of gravity--></x>
-                    </CG>
-                </security_kit>
-                <toilets>
-                    <mass units="kg" is_input="False">
-                        75.0<!--Mass of aircraft furniture_inp_data:weight:furniture:toilets:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            16.616796<!--toilets (D5): X-position of center of gravity--></x>
-                    </CG>
-                </toilets>
-            </furniture>
-            <propulsion>
-                <mass units="kg" is_input="False">
-                    7751.263132069291<!--Mass of the propulsion system--></mass>
-                <engine>
-                    <mass units="kg" is_input="False">
-                        7161.3348000000005<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            13.518747237993832<!--engine (B1): X-position of center of gravity--></x>
-                    </CG>
-                </engine>
-                <fuel_lines>
-                    <mass units="kg" is_input="False">
-                        467.2262657078984<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            13.518747237993832<!--fuel lines (B2): X-position of center of gravity--></x>
-                    </CG>
-                </fuel_lines>
-                <unconsumables>
-                    <mass units="kg" is_input="False">
-                        122.7020663613922<!--Mass of the propulsion system_inp_data:weight:propulsion:unconsumables:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            13.518747237993832<!--unconsumables (B3): X-position of center of gravity--></x>
-                    </CG>
-                </unconsumables>
-            </propulsion>
-            <systems>
-                <mass units="kg" is_input="False">
-                    7924.518483682383<!--Mass of aircraft systems--></mass>
-                <flight_kit>
-                    <mass units="kg" is_input="False">
-                        45.0<!--Mass of aircraft systems_inp_data:weight:systems:flight_kit:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            7.468795999999999<!--flight kit (C6): X-position of center of gravity--></x>
-                    </CG>
-                </flight_kit>
-                <navigation>
-                    <mass units="kg" is_input="False">
-                        497.33324970638404<!--Mass of aircraft systems_inp_data:weight:systems:navigation:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            5.5214368<!--navigation (C3): X-position of center of gravity--></x>
-                    </CG>
-                </navigation>
-                <transmission>
-                    <mass units="kg" is_input="False">
-                        200.0<!--Mass of aircraft systems_inp_data:weight:systems:transmission:mass--></mass>
-                    <CG>
-                        <x units="m" is_input="False">
-                            18.753682<!--transmission (C4): X-position of center of gravity--></x>
-                    </CG>
-                </transmission>
-                <life_support>
-                    <air_conditioning>
-                        <mass units="kg" is_input="False">
-                            942.4010810318936<!--Mass of aircraft systems_inp_data:weight:systems:life_support:air_conditioning:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.616796<!--air conditioning (C2): X-position of center of gravity--></x>
-                        </CG>
-                    </air_conditioning>
-                    <cabin_lighting>
-                        <mass units="kg" is_input="False">
-                            169.67684582876902<!--Mass of aircraft systems_inp_data:weight:systems:life_support:cabin_lighting:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.8783138<!--cabin lighting (C2): X-position of center of gravity--></x>
-                        </CG>
-                    </cabin_lighting>
-                    <de-icing>
-                        <mass units="kg" is_input="False">
-                            161.42429946605978<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de-icing:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.00760779312422<!--de-icing (C2): X-position of center of gravity--></x>
-                        </CG>
-                    </de-icing>
-                    <insulation>
-                        <mass units="kg" is_input="False">
-                            2254.2780945822174<!--Mass of aircraft systems_inp_data:weight:systems:life_support:insulation:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.8783138<!--insulation (C21): X-position of center of gravity--></x>
-                        </CG>
-                    </insulation>
-                    <oxygen>
-                        <mass units="kg" is_input="False">
-                            284.1<!--Mass of aircraft systems_inp_data:weight:systems:life_support:oxygen:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.616796<!--oxygen (C21): X-position of center of gravity--></x>
-                        </CG>
-                    </oxygen>
-                    <safety_equipment>
-                        <mass units="kg" is_input="False">
-                            432.713348<!--Mass of aircraft systems_inp_data:weight:systems:life_support:safety_equipment:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.104074021027174<!--safety equipment (C21): X-position of center of gravity--></x>
-                        </CG>
-                    </safety_equipment>
-                    <seats_crew_accommodation>
-                        <mass units="kg" is_input="False">
-                            126.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:seats_crew_accommodation:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.616796<!--seats crew accommodation (C21): X-position of center of gravity--></x>
-                        </CG>
-                    </seats_crew_accommodation>
-                </life_support>
-                <operational>
-                    <cargo_hold>
-                        <mass units="kg" is_input="False">
-                            298.1200782356778<!--Mass of aircraft systems_inp_data:weight:systems:operational:cargo_hold:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                16.616796<!--cargo hold (C52): X-position of center of gravity--></x>
-                        </CG>
-                    </cargo_hold>
-                    <radar>
-                        <mass units="kg" is_input="False">
-                            100.0<!--Mass of aircraft systems_inp_data:weight:systems:operational:radar:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                0.7501472800000001<!--radar (C51): X-position of center of gravity--></x>
-                        </CG>
-                    </radar>
-                </operational>
-                <power>
-                    <auxiliary_power_unit>
-                        <mass units="kg" is_input="False">
-                            287.3784652052712<!--Mass of aircraft systems_inp_data:weight:systems:power:auxiliary_power_unit:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                35.6319958<!--power (C1): X-position of center of gravity--></x>
-                        </CG>
-                    </auxiliary_power_unit>
-                    <electric_systems>
-                        <mass units="kg" is_input="False">
-                            1349.2217641988616<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                18.753682<!--power (C1): X-position of center of gravity--></x>
-                        </CG>
-                    </electric_systems>
-                    <hydraulic_systems>
-                        <mass units="kg" is_input="False">
-                            776.8712574272482<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
-                        <CG>
-                            <x units="m" is_input="False">
-                                18.753682<!--power (C1): X-position of center of gravity--></x>
-                        </CG>
-                    </hydraulic_systems>
-                </power>
-            </systems>
-            <fuel_tank>
-                <CG>
-                    <x units="m" is_input="False">
-                        16.18248269953227<!--fuel tank: X-position of center of gravity--></x>
-                </CG>
-            </fuel_tank>
-            <payload>
-                <PAX>
-                    <CG>
-                        <x units="m" is_input="False">
-                            16.616796<!--passengers: X-position of center of gravity--></x>
-                    </CG>
-                </PAX>
-                <front_fret>
-                    <CG>
-                        <x units="m" is_input="False">
-                            9.79403850537021<!--front fret: X-position of center of gravity--></x>
-                    </CG>
-                </front_fret>
-                <rear_fret>
-                    <CG>
-                        <x units="m" is_input="False">
-                            20.275951363582227<!--rear fret: X-position of center of gravity--></x>
-                    </CG>
-                </rear_fret>
-            </payload>
-        </weight>
-        <aerodynamics>
-            <aircraft>
-                <cruise>
-                    <CD is_input="False">[0.020874476432596573, 0.020877550061896597,
-                        0.020886361683979966, 0.020901015526194916, 0.020921615815889662,
-                        0.020948266780412464, 0.02098107264711154, 0.02102013764333513,
-                        0.021065565996431466, 0.021117461933748773, 0.02117592968263531,
-                        0.02124107347043928, 0.021312997524508943, 0.021391806072192526,
-                        0.02147760334083825, 0.02157049355779437, 0.0216705809504091,
-                        0.021777969746030693, 0.021892764172007365, 0.02201506845568737,
-                        0.022144986824418927, 0.022282623505550273, 0.022428082726429644,
-                        0.022581468714405275, 0.0227428856968254, 0.022912437901038255,
-                        0.023090229554392067, 0.023276364884235075, 0.023470948117915513,
-                        0.02367408348278162, 0.023885875206181614, 0.02410642751546375,
-                        0.024335844637976257, 0.024574230801067357, 0.024821690232085296,
-                        0.0250783271583783, 0.02534637508876729, 0.025628094094680993,
-                        0.02592366864433383, 0.026233338559469258, 0.026557401861893322,
-                        0.026896218875045827, 0.02725021770229808, 0.027619901246228675,
-                        0.028005855982029385, 0.02840876275542395, 0.028829409943430237,
-                        0.029268709397869033, 0.029727715690300215, 0.0302076492974863,
-                        0.030709924514086696, 0.03123618306102125, 0.03178833458256029,
-                        0.03236860550375779, 0.03297959806635927, 0.03362436179360119,
-                        0.03430648017507647, 0.035030176041082495, 0.035800439948751796,
-                        0.036623186977515244, 0.037505448690496754, 0.038455608740576575,
-                        0.03948369278766711, 0.040601726180275854, 0.04182417641269056,
-                        0.04316850192464728, 0.04465583465787812, 0.046311831309693505,
-                        0.048167737935064445, 0.05026172511374391, 0.05264056720018173,
-                        0.05536176037963988, 0.0584962019149593, 0.062131589149326524,
-                        0.06637674428655654, 0.0713671333894365, 0.07727193036717642,
-                        0.08430308562414493, 0.09272700349958896, 0.1028796248009675,
-                        0.11518596712096923, 0.13018551868170283, 0.1485653418069346,
-                        0.1712033617137722, 0.1992251526849988, 0.2340786660408794,
-                        0.2776328820163507, 0.33230846204663306, 0.4012513392683502,
-                        0.48856410598396455, 0.5553508645471106, 0.5562877880565893,
-                        0.5572398300201923, 0.558207094665268, 0.5591896862191647,
-                        0.5601877089092303, 0.5612012669628135, 0.5622304646072621,
-                        0.5632754060699247, 0.5643361955781492, 0.565412937359284,
-                        0.5665057356406774, 0.5676146946496775, 0.5687399186136327,
-                        0.5698815117598911, 0.5710395783158009, 0.5722142225087103,
-                        0.5734055485659677, 0.5746136607149215, 0.5758386631829194,
-                        0.5770806601973102, 0.5783397559854416, 0.5796160547746623,
-                        0.5809096607923202, 0.5822206782657636, 0.5835492114223412,
-                        0.5848953644894004, 0.5862592416942901, 0.5876409472643581,
-                        0.5890405854269531, 0.590458260409423, 0.591894076439116,
-                        0.5933481377433806, 0.5948205485495647, 0.5963114130850169,
-                        0.5978208355770851, 0.5993489202531177, 0.600895771340463,
-                        0.602461493066469, 0.6040461896584843, 0.6056499653438568,
-                        0.6072729243499349, 0.6089151709040667, 0.6105768092336005,
-                        0.6122579435658846, 0.6139586781282672, 0.6156791171480965,
-                        0.6174193648527208, 0.6191795254694884, 0.6209597032257472,
-                        0.6227600023488458, 0.6245805270661321, 0.6264213816049546,
-                        0.6282826701926617, 0.6301644970566012, 0.6320669664241216,
-                        0.633990182522571, 0.6359342495792977, 0.63789927182165,
-                        0.639885353476976]<!--Input defined by the mission.-->
-                        <compressibility is_input="False">[0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.001025528490322346,
-                            0.001025528490322346, 0.001025528490322346, 0.0010276577717950224,
-                            0.0010340721788208763, 0.001044851952266096, 0.001060132686525893,
-                            0.001080108176058095, 0.0011050345169542509, 0.0011352355852374634,
-                            0.0011711100561380642, 0.0012131401774996004, 0.0012619025676975858,
-                            0.0013180813764016425, 0.0013824842280843375, 0.0014560614669572966,
-                            0.0015399293424348073, 0.001635397921828059, 0.0017440046987086473,
-                            0.0018675550899986708, 0.0020081712934038637, 0.002168351323321527,
-                            0.0023510404756398656, 0.002559718012603585, 0.002798502537161831,
-                            0.0030722803790988957, 0.0033868623904974157, 0.0037491759071330683,
-                            0.004167500354537878, 0.00465175716527602, 0.00521386746050672,
-                            0.005868194507169543, 0.006632092517652276, 0.007526589206338793,
-                            0.008577237043191297, 0.009815177855832573, 0.01127847799666732,
-                            0.013013807592797168, 0.015078558602135845, 0.017543524060176063,
-                            0.02049629708275611, 0.02404559564634274, 0.02832678158637488,
-                            0.033508924584714314, 0.03980387081838143, 0.047477920399274925,
-                            0.05686690990750556, 0.06839575270841378, 0.08260383279676002,
-                            0.10017810826896235, 0.1219964001147802, 0.1491841783896485,
-                            0.18318929018648408, 0.2258806115128753, 0.27967869957669433,
-                            0.34772938328721664, 0.43413515071955644, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-                            0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-                            0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-                            0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-                            0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
-                            0.5]<!--increment of drag coefficient due to compressibility effects (shock waves) w.r.t. data:aerodynamics:aircraft:cruise:CL--></compressibility>
-                        <trim is_input="False">[0.0, 5.89e-06, 1.178e-05, 1.767e-05, 2.356e-05,
-                            2.945e-05, 3.534e-05, 4.123e-05, 4.712e-05, 5.3009999999999996e-05,
-                            5.89e-05, 6.479e-05, 7.068e-05, 7.657000000000001e-05, 8.246e-05,
-                            8.834999999999999e-05, 9.424e-05, 0.00010013, 0.00010601999999999999,
-                            0.00011191, 0.0001178, 0.00012369, 0.00012958, 0.00013547, 0.00014136,
-                            0.00014725, 0.00015314000000000001, 0.00015903, 0.00016492, 0.00017081,
-                            0.00017669999999999999, 0.00018259, 0.00018848, 0.00019437, 0.00020026,
-                            0.00020615000000000002, 0.00021203999999999998, 0.00021793, 0.00022382,
-                            0.00022971000000000002, 0.0002356, 0.00024149000000000002, 0.00024738,
-                            0.00025327, 0.00025916, 0.00026505, 0.00027094, 0.00027683000000000004,
-                            0.00028272, 0.00028861, 0.0002945, 0.00030039, 0.00030628000000000003,
-                            0.00031217, 0.00031806, 0.00032395000000000004, 0.00032984, 0.00033573,
-                            0.00034162, 0.00034751, 0.00035339999999999997, 0.00035929, 0.00036518,
-                            0.00037107, 0.00037696, 0.00038285, 0.00038874, 0.00039463000000000004,
-                            0.00040052, 0.00040641000000000006, 0.00041230000000000005, 0.00041819,
-                            0.00042407999999999996, 0.00042997, 0.00043586, 0.00044175, 0.00044764,
-                            0.00045353, 0.00045942000000000004, 0.00046531000000000003, 0.0004712,
-                            0.00047709000000000006, 0.00048298000000000004, 0.0004888700000000001,
-                            0.00049476, 0.0005006499999999999, 0.00050654, 0.00051243, 0.00051832,
-                            0.00052421, 0.0005301, 0.00053599, 0.00054188, 0.00054777,
-                            0.0005536600000000001, 0.00055955, 0.00056544, 0.00057133, 0.00057722,
-                            0.00058311, 0.000589, 0.00059489, 0.00060078, 0.00060667,
-                            0.0006125600000000001, 0.00061845, 0.00062434, 0.0006302300000000001,
-                            0.00063612, 0.00064201, 0.0006479000000000001, 0.00065379, 0.00065968,
-                            0.0006655700000000001, 0.00067146, 0.0006773500000000001, 0.00068324,
-                            0.0006891299999999999, 0.00069502, 0.00070091, 0.0007067999999999999,
-                            0.00071269, 0.00071858, 0.00072447, 0.00073036, 0.00073625, 0.00074214,
-                            0.00074803, 0.00075392, 0.00075981, 0.0007657, 0.0007715900000000001,
-                            0.00077748, 0.00078337, 0.0007892600000000001, 0.0007951500000000001,
-                            0.00080104, 0.0008069300000000001, 0.0008128200000000001, 0.00081871,
-                            0.0008246000000000001, 0.0008304899999999999, 0.00083638, 0.00084227,
-                            0.0008481599999999999, 0.00085405, 0.00085994, 0.0008658299999999999,
-                            0.00087172,
-                            0.00087761]<!--increment of drag coefficient due to aircraft trim w.r.t. data:aerodynamics:aircraft:cruise:CL--></trim>
-                    </CD>
-                    <CD0 is_input="False">[0.019848947942274226, 0.019842485531290165,
-                        0.01983446903252128, 0.019825002673315804, 0.01981419068102196,
-                        0.019802137282987995, 0.01978894670656214, 0.019774723179092624,
-                        0.019759570927927687, 0.019743594180415554, 0.019726897163904474,
-                        0.019709584105742667, 0.019691759233278375, 0.019673526773859834,
-                        0.01965499095483527, 0.019636256003552927, 0.019617426147361026,
-                        0.01959860561360782, 0.01957989862964152, 0.019561409422810382,
-                        0.01954324222046263, 0.019525501249946498, 0.01950829073861022,
-                        0.019491714913802034, 0.019475878002870168, 0.019460884233162862,
-                        0.019446837832028347, 0.019433843026814855, 0.019422004044870628,
-                        0.019411425113543896, 0.019402210460182888, 0.019394464312135845,
-                        0.019388290896751002, 0.019383794441376587, 0.01938107917336084,
-                        0.019380249320051987, 0.019381409108798275, 0.01938466276694793,
-                        0.019390114521849182, 0.019397868600850274, 0.019408029231299435,
-                        0.019420700640544904, 0.019435987055934908, 0.019453992704817687,
-                        0.019474821814541476, 0.0194985786124545, 0.019525367325905006,
-                        0.019555292182241217, 0.019588457408811374, 0.019624967232963714,
-                        0.019664925882046463, 0.019708437583407852, 0.01975560656439613,
-                        0.01980653705235952, 0.01986133327464626, 0.019920099458604585,
-                        0.019982939831582724, 0.02004995862092892, 0.020121260053991397,
-                        0.020196948358118395, 0.02027712776065815, 0.020361902488958892,
-                        0.020451376770368856, 0.020545654832236276, 0.020644840901909385,
-                        0.020749039206736423, 0.020858353974065623, 0.020972889431245215,
-                        0.021092749805623433, 0.021218039324548514, 0.021348862215368695,
-                        0.0214853227054322, 0.021627525022087268, 0.02177557339268214,
-                        0.021929572044565047, 0.022089625205084215, 0.02225583710158789,
-                        0.0224283119614243, 0.022607154011941678, 0.02279246748048826,
-                        0.02298435659441228, 0.023182925581061973, 0.023388278667785572,
-                        0.023600520081931312, 0.023819754050847422, 0.024046084801882146,
-                        0.024279616562383713, 0.02452045355970036, 0.024768700021180316,
-                        0.025024460174171818, 0.025287838246023094, 0.02555893846408239,
-                        0.02583786505569794, 0.026124722248217963, 0.026419614268990713,
-                        0.0267226453453644, 0.027033919704687284, 0.027353541574307576,
-                        0.02768161518157353, 0.028018244753833372, 0.028363534518435336,
-                        0.02871758870272765, 0.029080511534058558, 0.029452407239776296,
-                        0.029833380047229085, 0.030223534183765166, 0.030622973876732778,
-                        0.031031803353480155, 0.03145012684135552, 0.03187804856770711,
-                        0.032315672759883174, 0.03276310364523194, 0.03322044545110163,
-                        0.0336878024048405, 0.034165278733796746, 0.03465297866531864,
-                        0.0351510064267544, 0.03565946624545226, 0.036178462348760466,
-                        0.03670809896402725, 0.037248480318600834, 0.03779971063982945,
-                        0.03836189415506133, 0.03893513509164474, 0.03951953767692789,
-                        0.04011520613825901, 0.04072224470298633, 0.04134075759845811,
-                        0.04197084905202257, 0.04261262329102795, 0.043266184542822446,
-                        0.043931637034754355, 0.04460908499417188, 0.04529863264842323,
-                        0.046000384224856694, 0.04671444395082045, 0.04744091605366279,
-                        0.048179904760731904, 0.04893151429937602, 0.0496958488969434,
-                        0.05047301278078227, 0.05126311017824086, 0.052066245316667405,
-                        0.052882522423410155, 0.05371204572581732, 0.05455491945123716,
-                        0.055411247827017875, 0.05628113508050774, 0.057164685439054945,
-                        0.05806200313000778]<!--profile drag coefficient for whole aircraft in cruise conditions w.r.t. data:aerodynamics:aircraft:cruise:CL-->
-                        <clean is_input="False">[0.017937677622831123, 0.01793183748232416,
-                            0.017924592898329164, 0.017916038062063603, 0.01790626716474494,
-                            0.017895374397590643, 0.01788345395181818, 0.017870600018645013,
-                            0.017856906789288612, 0.01784246845496644, 0.017827379206895966,
-                            0.017811733236294654, 0.017795624734379973, 0.01777914789236939,
-                            0.017762396901480366, 0.017745465952930372, 0.01772844923793687,
-                            0.017711440947717334, 0.017694535273489218, 0.01767782640647,
-                            0.017661408537877142, 0.01764537585892811, 0.01762982256084037,
-                            0.01761484283483139, 0.017600530872118634, 0.017586980863919566,
-                            0.01757428700145166, 0.017562543475932373, 0.01755184447857918,
-                            0.01754228420060954, 0.017533956833240924, 0.017526956567690797,
-                            0.017521377595176628, 0.017517314106915875, 0.017514860294126012,
-                            0.0175141103480245, 0.017515158459828813, 0.01751809882075641,
-                            0.01752302562202476, 0.01753003305485133, 0.01753921531045358,
-                            0.017550666580048987, 0.01756448105485501, 0.017580752926089117,
-                            0.017599576384968774, 0.017621045622711447, 0.017645254830534605,
-                            0.017672298199655708, 0.01770226992129223, 0.017735264186661635,
-                            0.017771375186981388, 0.017810697113468946, 0.017853324157341793,
-                            0.017899350509817384, 0.01794887036211319, 0.018001977905446675,
-                            0.018058767331035303, 0.018119332830096545, 0.018183768593847863,
-                            0.018252168813506726, 0.0183246276802906, 0.01840123938541695,
-                            0.018482098120103246, 0.018567298075566948, 0.018656933443025527,
-                            0.018751098413696446, 0.018849887178797178, 0.018953393929545183,
-                            0.019061712857157926, 0.01917493815285288, 0.019293164007847505,
-                            0.019416484613359267, 0.019544994160605636, 0.01967878684080408,
-                            0.019817956845172062, 0.019962598364927045, 0.020112805591286503,
-                            0.020268672715467898, 0.020430293928688694, 0.020597763422166362,
-                            0.020771175387118365, 0.02095062401476217, 0.021136203496315245,
-                            0.021328008022995053, 0.02152613178601906, 0.021730668976604736,
-                            0.021941713785969548, 0.02215936040533096, 0.022383703025906435,
-                            0.022614835838913445, 0.02285285303556945, 0.023097848807091922,
-                            0.02334991734469833, 0.02360915283960613, 0.0238756494830328,
-                            0.024149501466195787, 0.024430802980312583, 0.02471964821660063,
-                            0.025016131366277415, 0.025320346620560395, 0.025632388170667035,
-                            0.0259523502078148, 0.02628032692322116, 0.026616412508103586,
-                            0.02696070115367953, 0.02731328705116647, 0.027674264391781868,
-                            0.0280437273667432, 0.028421770167267914, 0.02880848698457348,
-                            0.029203972009877382, 0.029608319434397075, 0.03002162344935002,
-                            0.030443978245953695, 0.030875478015425544, 0.03131621694898306,
-                            0.03176628923784369, 0.03222578907322491, 0.03269481064634419,
-                            0.033173448148418994, 0.03366179577066678, 0.03415994770430501,
-                            0.034667998140551166, 0.03518604127062271, 0.03571417128573711,
-                            0.036252482377111823, 0.03680106873596431, 0.03736002455351206,
-                            0.03792944402097253, 0.038509421329563184, 0.039100050670501464,
-                            0.03970142623500489, 0.04031364221429089, 0.040936792799576925,
-                            0.041570972182080494, 0.042216274553019024, 0.04287279410361003,
-                            0.04354062502507093, 0.0442198615086192, 0.044910597745472326,
-                            0.04561292792684776, 0.04632694624396297, 0.04705274688803542,
-                            0.047790424050282596, 0.048540071921921946, 0.04930178469417094,
-                            0.05007565655824703, 0.05086178170536772, 0.05166025432675043,
-                            0.05247116861361267]<!--like data:aerodynamics:aircraft:cruise:CD0 but without parasitic drag--></clean>
-                        <parasitic is_input="False">[0.0019112703194431035, 0.0019106480489660058,
-                            0.001909876134192117, 0.0019089646112522007, 0.00190792351627702,
-                            0.001906762885397352, 0.00190549275474396, 0.0019041231604476107,
-                            0.0019026641386390743, 0.001901125725449114, 0.001899517957008507,
-                            0.0018978508694480131, 0.0018961344988984025, 0.0018943788814904453,
-                            0.0018925940533549047, 0.0018907900506225546, 0.001888976909424158,
-                            0.0018871646658904853, 0.001885363356152303, 0.0018835830163403816,
-                            0.0018818336825854876, 0.0018801253910183877, 0.0018784681777698486,
-                            0.0018768720789706442, 0.001875347130751534, 0.0018739033692432953,
-                            0.0018725508305766879, 0.0018712995508824819, 0.0018701595662914475,
-                            0.0018691409129343549, 0.001868253626941964, 0.0018675077444450482,
-                            0.0018669133015743744, 0.0018664803344607128, 0.0018662188792348267,
-                            0.001866138972027486, 0.0018662506489694614, 0.0018665639461915191,
-                            0.0018670888998244227, 0.0018678355459989457, 0.0018688139208458548,
-                            0.0018700340604959169, 0.0018715060010798985, 0.00187323977872857,
-                            0.0018752454295727014, 0.0018775329897430526, 0.0018801124953704007,
-                            0.001882993982585509, 0.001886187487519144, 0.0018897030463020797,
-                            0.0018935506950650757, 0.0018977404699389057, 0.0019022824070543363,
-                            0.0019071865425421344, 0.0019124629125330701, 0.0019181215531579102,
-                            0.0019241725005474213, 0.0019306257908323736, 0.001937491460143534,
-                            0.001944779544611669, 0.0019525000803675488, 0.0019606631035419403,
-                            0.00196927865026561, 0.0019783567566693284, 0.0019879074588838586,
-                            0.0019979407930399776, 0.0020084667952684453, 0.002019495501700032,
-                            0.0020310369484655075, 0.0020431011716956354, 0.0020556982075211894,
-                            0.0020688380920729325, 0.0020825308614816317, 0.0020967865518780604,
-                            0.0021116151993929855, 0.00212702684015717, 0.002143031510301388,
-                            0.0021596392459564025, 0.0021768600832529836, 0.002194704058321898,
-                            0.0022131812072939162, 0.0022323015662998012, 0.0022520751714703267,
-                            0.0022725120589362595, 0.0022936222648283627, 0.00231541582527741,
-                            0.002337902776414165, 0.002361093154369401, 0.002384996995273881,
-                            0.0024096243352583722, 0.0024349852104536447, 0.0024610896569904686,
-                            0.0024879477109996107, 0.002515569408611834, 0.0025439647859579126,
-                            0.002573143879168613, 0.0026031167243747017, 0.0026338933577069457,
-                            0.002665483815296115, 0.0026978981332729766, 0.0027311463477683005,
-                            0.00276523849491285, 0.0028001846108373987, 0.00283599473167271,
-                            0.002872678893549554, 0.002910247132598697, 0.00294870948495091,
-                            0.002988075986736956, 0.003028356674087608, 0.00306956158313363,
-                            0.003111700750005792, 0.003154784210834864, 0.0031988220017516097,
-                            0.0032438241588868023, 0.0032898007183712018, 0.0033367617163355817,
-                            0.003384717188910709, 0.0034336771722273535, 0.0034836517024162753,
-                            0.003534650815608255, 0.003586684547934052, 0.0036397629355244335,
-                            0.003693896014510166, 0.00374909382102203, 0.0038053663911907787,
-                            0.0038627237611471854, 0.003921175967022017, 0.003980733044946047,
-                            0.004041405031050042, 0.004103201961464763, 0.004166133872320982,
-                            0.004230210799749466, 0.00429544277988099, 0.004361839848846305,
-                            0.0044294120427762, 0.004498169397801427, 0.00456812195005276,
-                            0.004639279735660973, 0.004711652790756818, 0.004785251151471076,
-                            0.004860084853934507, 0.0049361639342778915, 0.005013498428631982,
-                            0.00509209837312756, 0.005171973803895377, 0.005253134757066222,
-                            0.0053355912687708465, 0.005419353375140025, 0.005504431112304517,
-                            0.00559083451639511]<!--estimated parasitic drag for whole aircraft in cruise conditions (no high-lift) w.r.t. data:aerodynamics:aircraft:low_speed:CL--></parasitic>
-                    </CD0>
-                    <CL is_input="False">[0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09,
-                        0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22,
-                        0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34,
-                        0.35000000000000003, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41000000000000003, 0.42,
-                        0.43, 0.44, 0.45, 0.46, 0.47000000000000003, 0.48, 0.49, 0.5, 0.51, 0.52,
-                        0.53, 0.54, 0.55, 0.56, 0.5700000000000001, 0.58, 0.59, 0.6, 0.61, 0.62,
-                        0.63, 0.64, 0.65, 0.66, 0.67, 0.68, 0.6900000000000001, 0.7000000000000001,
-                        0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79, 0.8, 0.81,
-                        0.8200000000000001, 0.8300000000000001, 0.84, 0.85, 0.86, 0.87, 0.88, 0.89,
-                        0.9, 0.91, 0.92, 0.93, 0.9400000000000001, 0.9500000000000001, 0.96, 0.97,
-                        0.98, 0.99, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08, 1.09, 1.1,
-                        1.11, 1.12, 1.1300000000000001, 1.1400000000000001, 1.1500000000000001,
-                        1.16, 1.17, 1.18, 1.19, 1.2, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26, 1.27, 1.28,
-                        1.29, 1.3, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36, 1.37, 1.3800000000000001,
-                        1.3900000000000001, 1.4000000000000001, 1.41, 1.42, 1.43, 1.44, 1.45, 1.46,
-                        1.47, 1.48, 1.49]<!--Input defined by the mission.--></CL>
-                    <CL_alpha is_input="False">
-                        6.677136127381817<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
-                    <L_D_max is_input="False">
-                        16.373890433385228<!--max lift/drag ratio in cruise conditions--></L_D_max>
-                    <induced_drag_coefficient is_input="False">
-                        0.04190850901246978<!--multiply squared lift coefficient by this coefficient to get induced drag coefficient--></induced_drag_coefficient>
-                    <optimal_CD is_input="False">
-                        0.03236860550375779<!--drag coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CD>
-                    <optimal_CL is_input="False">
-                        0.53<!--lift coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CL>
-                    <oswald_coefficient is_input="False">
-                        0.7951114945215061<!--Oswald coefficient for cruise conditions--></oswald_coefficient>
-                </cruise>
-                <landing>
-                    <CL_max is_input="False">
-                        2.806181814239954<!--maximum lift coefficient in landing conditions--></CL_max>
-                    <CL_max_clean is_input="False">
-                        1.5824133961659907<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
-                    <CL_max_clean_2D is_input="True">
-                        1.94<!--maximum lift coefficient of 2D average profile in landing conditions without high-lift devices--></CL_max_clean_2D>
-                    <additional_CL_capacity is_input="False">
-                        0.12662735322464114<!--at landing, is equal to (maximum lift coefficient)-(maximum required lift coefficient)--></additional_CL_capacity>
-                    <mach is_input="False">
-                        0.19455259748464468<!--considered Mach number for landing phase--></mach>
-                </landing>
-            </aircraft>
-            <cruise>
-                <neutral_point>
-                    <x is_input="False">
-                        0.4184915420633031<!--X-position of neutral point - X-position of aircraft nose--></x>
-                </neutral_point>
-            </cruise>
-            <fuselage>
-                <cruise>
-                    <CD0 is_input="False">[0.007074812322606065, 0.007055638636022219,
-                        0.007036634189100808, 0.007017798981841832, 0.006999133014245291,
-                        0.006980636286311187, 0.006962308798039517, 0.006944150549430283,
-                        0.0069261615404834845, 0.006908341771199121, 0.006890691241577193,
-                        0.0068732099516177, 0.006855897901320644, 0.006838755090686022,
-                        0.006821781519713835, 0.006804977188404085, 0.006788342096756769,
-                        0.00677187624477189, 0.006755579632449445, 0.0067394522597894356,
-                        0.006723494126791862, 0.006707705233456724, 0.006692085579784021,
-                        0.0066766351657737534, 0.0066613539914259215, 0.006646242056740525,
-                        0.006631299361717563, 0.006616525906357038, 0.006601921690658947,
-                        0.006587486714623292, 0.006573220978250072, 0.006559124481539289,
-                        0.00654519722449094, 0.006531439207105026, 0.006517850429381548,
-                        0.0065044308913205055, 0.006491180592921899, 0.006478099534185727,
-                        0.006465187715111991, 0.00645244513570069, 0.006439871795951824,
-                        0.006427467695865394, 0.0064152328354414, 0.00640316721467984,
-                        0.006391270833580717, 0.006379543692144028, 0.006367985790369775,
-                        0.0063565971282579575, 0.006345377705808576, 0.006334327523021629,
-                        0.006323446579897118, 0.006312734876435041, 0.006302192412635401,
-                        0.006291819188498196, 0.006281615204023427, 0.0062715804592110925,
-                        0.006261714954061194, 0.00625201868857373, 0.006242491662748702,
-                        0.006233133876586109, 0.006223945330085952, 0.0062149260232482306,
-                        0.006206075956072944, 0.006197395128560093, 0.006188883540709678,
-                        0.006180541192521697, 0.006172368083996152, 0.006164364215133044,
-                        0.0061565295859323695, 0.0061488641963941305, 0.006141368046518328,
-                        0.00613404113630496, 0.006126883465754028, 0.006119895034865531,
-                        0.00611307584363947, 0.006106425892075844, 0.006099945180174654,
-                        0.0060936337079358985, 0.0060874914753595785, 0.006081518482445694,
-                        0.006075714729194245, 0.006070080215605232, 0.006064614941678654,
-                        0.006059318907414511, 0.006054192112812803, 0.006049234557873532,
-                        0.0060444462425966955, 0.0060398271669822945, 0.006035377331030329,
-                        0.006031096734740798, 0.006026985378113704, 0.006023043261149045,
-                        0.006019270383846821, 0.006015666746207032, 0.006012232348229679,
-                        0.006008967189914761, 0.0060058712712622786, 0.006002944592272232,
-                        0.00600018715294462, 0.005997598953279444, 0.005995179993276704,
-                        0.005992930272936398, 0.005990849792258528, 0.005988938551243094,
-                        0.0059871965498900954, 0.0059856237881995315, 0.005984220266171403,
-                        0.00598298598380571, 0.005981920941102453, 0.005981025138061631,
-                        0.005980298574683245, 0.005979741250967293, 0.005979353166913778,
-                        0.0059791343225226974, 0.0059790847177940525, 0.005979204352727844,
-                        0.005979493227324069, 0.005979951341582731, 0.0059805786955038276,
-                        0.00598137528908736, 0.005982341122333327, 0.0059834761952417305,
-                        0.005984780507812568, 0.005986254060045842, 0.0059878968519415515,
-                        0.005989708883499697, 0.0059916901547202766, 0.005993840665603292,
-                        0.005996160416148743, 0.00599864940635663, 0.006001307636226951,
-                        0.006004135105759708, 0.006007131814954901, 0.006010297763812529,
-                        0.006013632952332592, 0.006017137380515091, 0.006020811048360025,
-                        0.006024653955867395, 0.0060286661030372, 0.00603284748986944,
-                        0.006037198116364116, 0.006041717982521228, 0.006046407088340775,
-                        0.0060512654338227565, 0.006056293018967174, 0.006061489843774027,
-                        0.006066855908243315, 0.0060723912123750385, 0.006078095756169198,
-                        0.006083969539625793]<!--profile drag coefficient for fuselage w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
-                    <CnBeta is_input="False">
-                        -0.10012822148980342<!--derivative of yawing moment against sideslip angle for fuselage in cruise conditions--></CnBeta>
-                </cruise>
-            </fuselage>
-            <high_lift_devices>
-                <landing>
-                    <CD is_input="False">
-                        0.03309219200000092<!--increment of CD due to high-lift devices for landing phase--></CD>
-                    <CL is_input="False">
-                        1.2237684180739636<!--increment of CL due to high-lift devices for landing phase--></CL>
-                </landing>
-            </high_lift_devices>
-            <horizontal_tail>
-                <cruise>
-                    <CD0 is_input="False">
-                        0.0016930843394035505<!--profile drag coefficient for horizontal tail in cruise conditions--></CD0>
-                    <CL_alpha is_input="False">
-                        3.4698175649817595<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in cruise conditions--></CL_alpha>
-                </cruise>
-            </horizontal_tail>
-            <nacelles>
-                <cruise>
-                    <CD0 is_input="False">
-                        0.001538668477468236<!--profile drag coefficient for nacelles in cruise conditions--></CD0>
-                </cruise>
-            </nacelles>
-            <pylons>
-                <cruise>
-                    <CD0 is_input="False">
-                        0.00032489189455345004<!--profile drag coefficient for pylons in cruise conditions--></CD0>
-                </cruise>
-            </pylons>
-            <vertical_tail>
-                <cruise>
-                    <CD0 is_input="False">
-                        0.001301681485811169<!--profile drag coefficient for vertical tail in cruise conditions--></CD0>
-                    <CL_alpha is_input="False">
-                        2.546156443275808<!--derivative of lift coefficient of horizontal tail with respect to local "angle of attack" in cruise conditions--></CL_alpha>
-                    <CnBeta units="m**2" is_input="False">
-                        0.24057495748980345<!--derivative of yawing moment against sideslip angle for vertical tail in cruise conditions--></CnBeta>
-                </cruise>
-            </vertical_tail>
-            <wing>
-                <cruise>
-                    <CD0 is_input="False">[0.006004539102988653, 0.006017872649065538,
-                        0.006029632511991953, 0.006039912882985367, 0.006048807953263245,
-                        0.006056411914043053, 0.006062818956542259, 0.006068123271978326,
-                        0.006072419051568723, 0.006075800486530915, 0.006078361768082369,
-                        0.0060801970874405495, 0.006081400635822926, 0.006082066604446963,
-                        0.006082289184530126, 0.006082162567289882, 0.006081780943943697,
-                        0.006081238505709039, 0.006080629443803371, 0.006080047949444162,
-                        0.006079588213848878, 0.006079344428234984, 0.006079410783819947,
-                        0.006079881471821233, 0.0060808506834563085, 0.006082412609942639,
-                        0.006084661442497692, 0.006087691372338932, 0.006091596590683829,
-                        0.006096471288749845, 0.0061024096577544495, 0.006109505888915106,
-                        0.006117854173449283, 0.006127548702574446, 0.00613868366750806,
-                        0.006151353259467593, 0.00616565166967051, 0.00618167308933428,
-                        0.006199511709676365, 0.006219261721914234, 0.0062410173172653535,
-                        0.0062648726869471896, 0.006290922022177206, 0.0063192595141728725,
-                        0.006349979354151654, 0.006383175733331016, 0.006418942842928425,
-                        0.0064573748741613484, 0.006498566018247252, 0.0065426104664036006,
-                        0.006589602409847865, 0.006639636039797503, 0.006692805547469989,
-                        0.006749205124082784, 0.00680892896085336, 0.006872071248999178,
-                        0.006938726179737706, 0.007008987944286412, 0.007082950733862758,
-                        0.007160708739684212, 0.007242356152968247, 0.007327987164932317,
-                        0.007417695966793899, 0.007511576749770451, 0.007609723705079447,
-                        0.007712231023938347, 0.007819192897564622, 0.007930703517175737,
-                        0.008046857073989154, 0.008167747759222346, 0.008293469764092773,
-                        0.008424117279817905, 0.008559784497615205, 0.008700565608702146,
-                        0.00884655480429619, 0.008997846275614799, 0.009154534213875446,
-                        0.009316712810295596, 0.009484476256092712, 0.009657918742484265,
-                        0.009837134460687716, 0.010022217601920534, 0.010213262357400188,
-                        0.010410362918344138, 0.010613613475969853, 0.010823108221494801,
-                        0.01103894134613645, 0.01126120704111226, 0.011489999497639701,
-                        0.011725412906936242, 0.011967541460219342, 0.012216479348706472,
-                        0.012472320763615104, 0.012735159896162692, 0.013005090937566716,
-                        0.013282208079044623, 0.0135666055118139, 0.013858377427091995,
-                        0.014157618016096392, 0.014464421470044548, 0.014778881980153927,
-                        0.015101093737641996, 0.015431150933726228, 0.015769147759624087,
-                        0.01611517840655303, 0.016469337065730533, 0.01683171792837406,
-                        0.017202415185701085, 0.01758152302892906, 0.017969135649275447,
-                        0.018365347237957734, 0.01877025198619338, 0.019183944085199838,
-                        0.019606517726194594, 0.020038067100395088, 0.02047868639901881,
-                        0.020928469813283213, 0.02138751153440577, 0.021855905753603952,
-                        0.02233374666209522, 0.022821128451097045, 0.02331814531182687,
-                        0.023824891435502187, 0.02434146101334046, 0.024867948236559148,
-                        0.025404447296375716, 0.025951052384007623, 0.02650785769067236,
-                        0.027074957407587377, 0.027652445725970143, 0.028240416837038103,
-                        0.028838964932008767, 0.029448184202099575, 0.030068168838527986,
-                        0.03069901303251149, 0.03134081097526752, 0.03199365685801359,
-                        0.03265764487196712, 0.03333286920834559, 0.03401942405836648,
-                        0.03471740361324724, 0.03542690206420533, 0.036148013602458236,
-                        0.03688083241922343, 0.03762545270571836, 0.0383819686531605,
-                        0.0391504744527673, 0.03993106429575627, 0.04072383237334482,
-                        0.04152887287675047]<!--profile drag coefficient for wing w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
-                    <reynolds is_input="False">
-                        6124998.624249204<!--Reynolds number based on wing mean aerodynamic chord in cruise conditions--></reynolds>
-                </cruise>
-                <landing>
-                    <reynolds is_input="False">
-                        16972962.667044908<!--Reynolds number based on wing mean aerodynamic chord in landing conditions--></reynolds>
-                </landing>
-            </wing>
-        </aerodynamics>
-    </data>
-    <settings>
-        <geometry>
-            <horizontal_tail>
-                <position_ratio_on_fuselage is_input="True">
-                    0.91<!--(does not apply for T-tails) distance to aircraft nose of 25% MAC of horizontal tail divided by fuselage length--></position_ratio_on_fuselage>
-            </horizontal_tail>
-        </geometry>
-        <aerodynamics>
-            <wing>
-                <CD>
-                    <fuselage_interaction is_input="True">0.04</fuselage_interaction>
-                </CD>
-            </wing>
-        </aerodynamics>
-        <weight>
-            <aircraft>
-                <CG>
-                    <range is_input="True">
-                        0.3<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
-                    <aft>
-                        <MAC_position>
-                            <margin is_input="True">
-                                0.05<!--Added margin for getting most aft CG position, as ratio of mean aerodynamic chord--></margin>
-                        </MAC_position>
-                    </aft>
-                </CG>
-                <payload>
-                    <design_mass_per_passenger units="kg" is_input="True">
-                        90.72<!--Design value of mass per passenger--></design_mass_per_passenger>
-                    <max_mass_per_passenger units="kg" is_input="True">
-                        130.72<!--Maximum value of mass per passenger--></max_mass_per_passenger>
-                </payload>
-            </aircraft>
-            <airframe>
-                <flight_controls>
-                    <mass>
-                        <k_fc is_input="True">
-                            0.000135<!--flight controls (A4): 0.85e-4 if electrical, 1.35e-4 if conventional--></k_fc>
-                    </mass>
-                </flight_controls>
-                <fuselage>
-                    <mass>
-                        <k_fus is_input="True">
-                            1.0<!--correction coefficient: 1.00 if all engines under wing / 1.02 with 2 engines at rear / 1.03 if 3 engines at rear / 1.05 if 1 engine in vertical tail (with or without 2 engines under wing)--></k_fus>
-                        <k_lg is_input="True">
-                            1.05<!--correction coefficient: 1.05 if main landing gear under wing / 1.10 if main landing gear under fuselage--></k_lg>
-                    </mass>
-                </fuselage>
-                <landing_gear>
-                    <front>
-                        <weight_ratio is_input="True">
-                            0.08<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
-                    </front>
-                </landing_gear>
-                <wing>
-                    <mass>
-                        <k_mvo is_input="True">1.39<!--1.39 for Airbus type aircrafts--></k_mvo>
-                    </mass>
-                </wing>
-            </airframe>
-            <systems>
-                <power>
-                    <mass>
-                        <k_elec is_input="True">
-                            1.0<!--electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)--></k_elec>
-                    </mass>
-                </power>
-            </systems>
-        </weight>
-        <mission>
-            <sizing>
-                <breguet>
-                    <climb>
-                        <mass_ratio is_input="True">
-                            0.97<!--Input defined by the mission.--></mass_ratio>
-                    </climb>
-                    <descent>
-                        <mass_ratio is_input="True">
-                            0.98<!--Input defined by the mission.--></mass_ratio>
-                    </descent>
-                    <reserve>
-                        <mass_ratio is_input="True">
-                            0.06<!--Input defined by the mission.--></mass_ratio>
-                    </reserve>
-                </breguet>
-            </sizing>
-        </mission>
-    </settings>
-    <tuning>
-        <propulsion>
-            <rubber_engine>
-                <SFC>
-                    <k_cr is_input="True">
-                        1.0<!--correction ratio to apply to the computed SFC at cruise ceiling--></k_cr>
-                    <k_sl is_input="True">
-                        1.0<!--correction ratio to apply to the computed SFC at sea level--></k_sl>
-                </SFC>
-            </rubber_engine>
-        </propulsion>
-        <aerodynamics>
-            <aircraft>
-                <cruise>
-                    <CD>
-                        <k is_input="True">
-                            1.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></k>
-                        <offset is_input="True">
-                            0.0<!--correction offset to apply to computed drag coefficient in cruise conditions--></offset>
-                        <compressibility>
-                            <characteristic_mach_increment is_input="True">
-                                0.0<!--Increment to apply to the computed characteristic Mach (where compressibility drag is 20 d.c.)--></characteristic_mach_increment>
-                            <max_value is_input="True">
-                                0.5<!--maximum authorized value for compressibility drag. Allows to prevent the model from overestimating the compressibility effect, especially for aircraft models after year 2000.--></max_value>
-                        </compressibility>
-                        <winglet_effect>
-                            <k is_input="True">
-                                0.87<!--correction ratio to apply to computed induced drag coefficient in cruise conditions--></k>
-                            <offset is_input="True">
-                                0.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></offset>
-                        </winglet_effect>
-                    </CD>
-                    <CL>
-                        <k is_input="True">
-                            1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
-                        <offset is_input="True">
-                            0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
-                        <winglet_effect>
-                            <k is_input="True">
-                                1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
-                            <offset is_input="True">
-                                0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
-                        </winglet_effect>
-                    </CL>
-                </cruise>
-                <landing>
-                    <CL_max>
-                        <landing_gear_effect>
-                            <k is_input="True">
-                                1.0<!--correction ratio to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear--></k>
-                        </landing_gear_effect>
-                    </CL_max>
-                </landing>
-            </aircraft>
-            <high_lift_devices>
-                <landing>
-                    <CD>
-                        <multi_slotted_flap_effect>
-                            <k is_input="True">
-                                1.0<!--correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps--></k>
-                        </multi_slotted_flap_effect>
-                    </CD>
-                    <CL>
-                        <multi_slotted_flap_effect>
-                            <k is_input="True">
-                                1.0<!--correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps--></k>
-                        </multi_slotted_flap_effect>
-                    </CL>
-                </landing>
-            </high_lift_devices>
-        </aerodynamics>
-        <weight>
-            <airframe>
-                <flight_controls>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--flight controls (A4): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--flight controls (A4): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </flight_controls>
-                <fuselage>
-                    <mass>
-                        <k is_input="True">
-                            1.1<!--fuselage (A2): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--fuselage (A2): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </fuselage>
-                <horizontal_tail>
-                    <mass>
-                        <k is_input="True">
-                            1.08<!--horizontal tail (A31): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--horizontal tail (A31): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </horizontal_tail>
-                <landing_gear>
-                    <mass>
-                        <k is_input="True">
-                            0.85<!--landing gears (A5): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--landing gears (A5): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </landing_gear>
-                <paint>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--paint (A7): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--paint (A7): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </paint>
-                <pylon>
-                    <mass>
-                        <k is_input="True">
-                            0.85<!--pylon (A6): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--pylon (A6): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </pylon>
-                <vertical_tail>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--vertical tail (A32): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--vertical tail (A32): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </vertical_tail>
-                <wing>
-                    <mass>
-                        <k is_input="True">
-                            1.05<!--wing (A1): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--wing (A1): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                    <bending_sizing>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--wing bending sizing (A11): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--wing bending sizing (A11): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </bending_sizing>
-                    <reinforcements>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--wing reinforcements (A14): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--wing reinforcements (A14): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </reinforcements>
-                    <ribs>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--wing ribs (A13): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--wing ribs (A13): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </ribs>
-                    <secondary_parts>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--wing secondary parts (A15): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--wing secondary parts (A15): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </secondary_parts>
-                    <shear_sizing>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--wing shear sizing (A12): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--wing shear sizing (A12): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </shear_sizing>
-                </wing>
-            </airframe>
-            <furniture>
-                <food_water>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--food water (D3): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--food water (D3): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </food_water>
-                <passenger_seats>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--passenger seats (D2): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--passenger seats (D2): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </passenger_seats>
-                <security_kit>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--security kit (D4): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--security kit (D4): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </security_kit>
-                <toilets>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--toilets (D5): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--toilets (D5): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </toilets>
-            </furniture>
-            <propulsion>
-                <engine>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--engine (B1): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--engine (B1): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </engine>
-                <fuel_lines>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--fuel lines (B2): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--fuel lines (B2): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </fuel_lines>
-                <unconsumables>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--unconsumables (B3): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--unconsumables (B3): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </unconsumables>
-            </propulsion>
-            <systems>
-                <flight_kit>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--flight kit (C6): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--flight kit (C6): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </flight_kit>
-                <navigation>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--navigation (C3): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--navigation (C3): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </navigation>
-                <operational>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--operational (C5): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--operational (C5): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </operational>
-                <transmission>
-                    <mass>
-                        <k is_input="True">
-                            1.0<!--transmission (C4): correction ratio to be applied on computed mass--></k>
-                        <offset units="kg" is_input="True">
-                            0.0<!--transmission (C4): correction offset to be applied on computed mass--></offset>
-                    </mass>
-                </transmission>
-                <life_support>
-                    <air_conditioning>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--air conditioning (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--air conditioning (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </air_conditioning>
-                    <cabin_lighting>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--cabin lighting (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--cabin lighting (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </cabin_lighting>
-                    <de-icing>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--de-icing (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--de-icing (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </de-icing>
-                    <insulation>
-                        <mass>
-                            <k is_input="True">
-                                2.0<!--insulation (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--insulation (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </insulation>
-                    <oxygen>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--oxygen (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--oxygen (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </oxygen>
-                    <safety_equipment>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--safety equipment (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--safety equipment (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </safety_equipment>
-                    <seats_crew_accommodation>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--seats crew accommodation (C21): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--seats crew accommodation (C21): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </seats_crew_accommodation>
-                </life_support>
-                <power>
-                    <auxiliary_power_unit>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </auxiliary_power_unit>
-                    <electric_systems>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </electric_systems>
-                    <hydraulic_systems>
-                        <mass>
-                            <k is_input="True">
-                                1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
-                            <offset units="kg" is_input="True">
-                                0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
-                        </mass>
-                    </hydraulic_systems>
-                </power>
-            </systems>
-        </weight>
-    </tuning>
+  <data>
+    <TLAR>
+      <NPAX is_input="True">150.0<!--top-level requirement: number of passengers, assuming a classic eco/business class repartition--></NPAX>
+      <approach_speed units="knot" is_input="True">132.0<!--top-level requirement: approach speed--></approach_speed>
+      <cruise_mach is_input="True">0.78<!--Input defined by the mission.--></cruise_mach>
+      <range units="nmi" is_input="True">2750.0<!--Input defined by the mission.--></range>
+    </TLAR>
+    <geometry>
+      <has_T_tail is_input="True">0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <aircraft>
+        <wetted_area units="m**2" is_input="False">810.149242366622<!--total wetted area--></wetted_area>
+      </aircraft>
+      <cabin>
+        <NPAX1 is_input="False">157.0<!--number of passengers if there are only economical class seats--></NPAX1>
+        <aisle_width units="m" is_input="True">0.48<!--width of aisles--></aisle_width>
+        <exit_width units="m" is_input="True">0.51<!--width of exits--></exit_width>
+        <length units="m" is_input="False">30.380964840000004<!--cabin length--></length>
+        <containers>
+          <count_by_row is_input="True">1.0<!--number of cargo containers along width--></count_by_row>
+        </containers>
+        <crew_count>
+          <commercial is_input="False">4.0<!--number of commercial crew members--></commercial>
+          <technical is_input="True">2.0<!--number of technical crew members--></technical>
+        </crew_count>
+        <seats>
+          <economical>
+            <count_by_row is_input="True">6.0<!--number of economical class seats along width--></count_by_row>
+            <length units="m" is_input="True">0.86<!--length of economical class seats--></length>
+            <width units="m" is_input="True">0.46<!--width of economical class seats--></width>
+          </economical>
+        </seats>
+      </cabin>
+      <flap>
+        <chord_ratio is_input="True">0.197<!--mean value of (flap chord)/(section chord)--></chord_ratio>
+        <span_ratio is_input="True">0.8<!--ratio (width of flaps)/(total span)--></span_ratio>
+      </flap>
+      <fuselage>
+        <PAX_length units="m" is_input="False">22.87<!--length of passenger-dedicated zone--></PAX_length>
+        <front_length units="m" is_input="False">6.901795999999999<!--length of front non-cylindrical part of the fuselage--></front_length>
+        <length units="m" is_input="False">37.507364<!--total fuselage length--></length>
+        <maximum_height units="m" is_input="False">4.05988<!--maximum fuselage height--></maximum_height>
+        <maximum_width units="m" is_input="False">3.91988<!--maximum fuselage width--></maximum_width>
+        <rear_length units="m" is_input="False">14.615568<!--length of rear non-cylindrical part of the fuselage--></rear_length>
+        <wetted_area units="m**2" is_input="False">401.95600094323777<!--wetted area of fuselage--></wetted_area>
+      </fuselage>
+      <horizontal_tail>
+        <area units="m**2" is_input="False">34.4824294323336<!--horizontal tail area--></area>
+        <aspect_ratio is_input="True">4.28778048454<!--aspect ratio of horizontal tail--></aspect_ratio>
+        <span units="m" is_input="False">12.159485507512253<!--horizontal tail span--></span>
+        <sweep_0 units="deg" is_input="False">33.31651496553977<!--sweep angle at leading edge of horizontal tail--></sweep_0>
+        <sweep_100 units="deg" is_input="False">8.80894178425667<!--sweep angle at trailing edge of horizontal tail--></sweep_100>
+        <sweep_25 units="deg" is_input="True">28.0<!--sweep angle at 25% chord of horizontal tail--></sweep_25>
+        <taper_ratio is_input="True">0.3<!--taper ratio of horizontal tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.1<!--thickness ratio of horizontal tail--></thickness_ratio>
+        <wetted_area units="m**2" is_input="False">68.9648588646672<!--wetted area of horizontal tail--></wetted_area>
+        <MAC>
+          <length units="m" is_input="False">3.1099219411822054<!--_inp_data:geometry:horizontal_tail:MAC:length--></length>
+          <y units="m" is_input="False">2.494253437438411<!--Y-position of mean aerodynamic chord of horizontal tail--></y>
+          <at25percent>
+            <x units="m" is_input="False">34.131701240000005<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x--><from_wingMAC25 units="m" is_input="False">17.524905240000006<!--_inp_data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">2.4169281109683585<!--X-position of the 25% of mean aerodynamic chord of horizontal tail w.r.t. leading edge of root chord--></local></x>
+          </at25percent>
+          <leading_edge>
+            <x units="m" is_input="False">33.35422075470446<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x--><local units="m" is_input="False">1.639447625672807<!--_inp_data:geometry:horizontal_tail:MAC:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </MAC>
+        <center>
+          <chord units="m" is_input="False">4.362840133313165<!--chord length at center of horizontal tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">31.71477312903165<!--_inp_data:geometry:horizontal_tail:center:leading_edge:x--><local units="m" is_input="False">-2.220446049250313e-16<!--X-position of the leading edge at center of horizontal tail w.r.t. leading edge of center chord--></local></x>
+          </leading_edge>
+        </center>
+        <tip>
+          <chord units="m" is_input="False">1.3088520399939496<!--chord length at tip of horizontal tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">35.710926716609116<!--X-position of leading edge at horizontal tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">3.996153587577467<!--_inp_data:geometry:horizontal_tail:tip:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </tip>
+      </horizontal_tail>
+      <landing_gear>
+        <height units="m" is_input="False">3.0411414104151127<!--height of landing gear--></height>
+      </landing_gear>
+      <propulsion>
+        <layout is_input="True">1.0<!--position of engines (1=under the wing / 2=rear fuselage)--></layout>
+        <engine>
+          <count is_input="True">2.0<!--number of engines--></count>
+          <y_ratio is_input="True">0.34<!--engine position with respect to total span--></y_ratio>
+        </engine>
+        <fan>
+          <length units="m" is_input="False">3.1268896238914476<!--engine length--></length>
+        </fan>
+        <nacelle>
+          <diameter units="m" is_input="False">2.1722438645822235<!--nacelle diameter--></diameter>
+          <length units="m" is_input="False">5.2114827064857465<!--nacelle length--></length>
+          <wetted_area units="m**2" is_input="False">21.6092<!--wetted area of nacelle--></wetted_area>
+          <y units="m" is_input="False">6.003163746683879<!--Y-position of nacelle center--></y>
+        </nacelle>
+        <pylon>
+          <length units="m" is_input="False">5.732630977134321<!--pylon length--></length>
+          <wetted_area units="m**2" is_input="False">7.56322<!--wetted area of pylon--></wetted_area>
+        </pylon>
+      </propulsion>
+      <slat>
+        <chord_ratio is_input="True">0.177<!--mean value of slat chord)/(section chord)--></chord_ratio>
+        <span_ratio is_input="True">0.9<!--ratio (width of slats)/(total span)--></span_ratio>
+      </slat>
+      <vertical_tail>
+        <area units="m**2" is_input="False">27.675384276322472<!--vertical tail area--></area>
+        <aspect_ratio is_input="True">1.74462618632<!--aspect ratio of vertical tail--></aspect_ratio>
+        <span units="m" is_input="False">6.948611377259697<!--vertical tail span--></span>
+        <sweep_0 units="deg" is_input="False">40.51480176597914<!--sweep angle at leading edge of vertical tail--></sweep_0>
+        <sweep_100 units="deg" is_input="False">13.346519785400803<!--sweep angle at trailing edge of vertical tail--></sweep_100>
+        <sweep_25 units="deg" is_input="True">35.0<!--sweep angle at 25% chord of vertical tail--></sweep_25>
+        <taper_ratio is_input="True">0.3<!--taper ratio of vertical tail--></taper_ratio>
+        <thickness_ratio is_input="True">0.1<!--thickness ratio of vertical tail--></thickness_ratio>
+        <wetted_area units="m**2" is_input="False">58.118306980277204<!--wetted area of vertical tail--></wetted_area>
+        <MAC>
+          <length units="m" is_input="False">4.367797229764228<!--_inp_data:geometry:vertical_tail:MAC:length--></length>
+          <z units="m" is_input="False">2.8507123599014137<!--Z-position of mean aerodynamic chord of vertical tail--></z>
+          <at25percent>
+            <x units="m" is_input="False">33.00648032<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. nose of aircraft--><from_wingMAC25 units="m" is_input="False">16.399684320000002<!--_inp_data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25--></from_wingMAC25><local units="m" is_input="False">3.5279616142533383<!--X-position of the 25% of mean aerodynamic chord of vertical tail w.r.t. leading edge of root chord--></local></x>
+          </at25percent>
+          <leading_edge>
+            <x units="m" is_input="False">31.914531012558946<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">2.436012306812281<!--_inp_data:geometry:vertical_tail:MAC:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </MAC>
+        <root>
+          <chord units="m" is_input="False">6.12748532233111<!--chord length at root of vertical tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">29.478518705746666<local units="m" is_input="False">0.0<!--X-position of leading edge at vertical tail tip w.r.t. leading edge of root chord--></local></x>
+          </leading_edge>
+        </root>
+        <tip>
+          <chord units="m" is_input="False">1.838245596699333<!--chord length at tip of vertical tail--></chord>
+          <leading_edge>
+            <x units="m" is_input="False">35.416298703601605<!--X-position of leading edge at vertical tail tip w.r.t. nose of aircraft--><local units="m" is_input="False">5.937779997854936<!--_inp_data:geometry:vertical_tail:tip:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </tip>
+      </vertical_tail>
+      <wing>
+        <area units="m**2" is_input="False">131.53889808769554<!--wing reference area--></area>
+        <aspect_ratio is_input="True">9.48<!--wing aspect ratio--></aspect_ratio>
+        <b_50 units="m" is_input="False">38.24004165494306<!--actual length between root and tip along 50% of chord--></b_50>
+        <outer_area units="m**2" is_input="False">111.38261786110664<!--wing area outside of fuselage--></outer_area>
+        <span units="m" is_input="False">35.312727921669875<!--wing span--></span>
+        <sweep_0 units="deg" is_input="False">27.34279936678936<!--sweep angle at leading edge of wing--></sweep_0>
+        <sweep_100_inner units="deg" is_input="False">17.4310428125833<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
+        <sweep_100_outer units="deg" is_input="False">17.4310428125833<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
+        <sweep_100_ratio is_input="True">0.0<!--ratio inner/outer for sweep angles at trailing edge of wing--></sweep_100_ratio>
+        <sweep_25 units="deg" is_input="True">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <taper_ratio is_input="False">0.38<!--taper ratio of wing--></taper_ratio>
+        <thickness_ratio is_input="False">0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
+        <virtual_taper_ratio is_input="True">0.38<!--taper ratio of wing computed from virtual root chord--></virtual_taper_ratio>
+        <wetted_area units="m**2" is_input="False">222.76523572221328<!--wetted area of wing--></wetted_area>
+        <MAC>
+          <length units="m" is_input="False">3.9944277942067328<!--_inp_data:geometry:wing:MAC:length--></length>
+          <y units="m" is_input="False">7.4601368689260745<!--Y-position of mean aerodynamic chord of wing--></y>
+          <at25percent>
+            <x units="m" is_input="True">16.606796<!--_inp_data:geometry:wing:MAC:at25percent:x--></x>
+          </at25percent>
+          <leading_edge>
+            <x units="m" is_input="False">15.608189051448315<local units="m" is_input="False">2.921716505919591<!--_inp_data:geometry:wing:MAC:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </MAC>
+        <kink>
+          <chord units="m" is_input="False">5.142065615055217<!--chord length at wing kink--></chord>
+          <span_ratio is_input="True">0.0<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
+          <thickness_ratio is_input="False">0.15921402692414266<!--thickness ratio at wing kink--></thickness_ratio>
+          <y units="m" is_input="False">1.95994<!--Y-position of wing kink--></y>
+          <leading_edge>
+            <x units="m" is_input="False">12.686472545528725<local units="m" is_input="False">0.0<!--_inp_data:geometry:wing:kink:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </kink>
+        <root>
+          <chord units="m" is_input="False">5.142065615055217<!--chord length at wing root--></chord>
+          <thickness_ratio is_input="False">0.15921402692414266<!--thickness ratio at wing root--></thickness_ratio>
+          <virtual_chord units="m" is_input="False">5.142065615055217<!--virtual chord length at wing root if sweep angle of trailing edge of outer wing part was on the whole wing (no kink)--></virtual_chord>
+          <y units="m" is_input="False">1.95994<!--Y-position of wing root--></y>
+          <leading_edge>
+            <x units="m" is_input="False">12.686472545528725</x>
+          </leading_edge>
+        </root>
+        <tip>
+          <chord units="m" is_input="False">1.9539849337209825<!--chord length at wing tip--></chord>
+          <thickness_ratio is_input="False">0.11042263157642153<!--thickness ratio at wing tip--></thickness_ratio>
+          <y units="m" is_input="False">17.656363960834938<!--Y-position of wing tip--></y>
+          <leading_edge>
+            <x units="m" is_input="False">20.802855414447233<local units="m" is_input="False">8.116382868918507<!--_inp_data:geometry:wing:tip:leading_edge:x:local--></local></x>
+          </leading_edge>
+        </tip>
+        <spar_ratio>
+          <front>
+            <kink is_input="True">0.15<!--ratio (front spar position)/(chord length) at wing kink--></kink>
+            <root is_input="True">0.11<!--ratio (front spar position)/(chord length) at wing root--></root>
+            <tip is_input="True">0.27<!--ratio (front spar position)/(chord length) at wing tip--></tip>
+          </front>
+          <rear>
+            <kink is_input="True">0.66<!--ratio (rear spar position)/(chord length) at wing kink--></kink>
+            <root is_input="True">0.57<!--ratio (rear spar position)/(chord length) at wing root--></root>
+            <tip is_input="True">0.56<!--ratio (rear spar position)/(chord length) at wing tip--></tip>
+          </rear>
+        </spar_ratio>
+      </wing>
+    </geometry>
+    <handling_qualities>
+      <static_margin is_input="False">0.032899870561865885<!--(X-position of neutral point - X-position of center of gravity ) / (mean aerodynamic chord)--></static_margin>
+    </handling_qualities>
+    <load_case>
+      <gust_intensity is_input="True">0.0<!--a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated--></gust_intensity>
+      <manoeuvre_load_factor is_input="True">2.5<!--limit positive manoeuvring load factor--></manoeuvre_load_factor>
+      <lc1>
+        <U_gust units="m/s" is_input="True">15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
+        <Vc_EAS units="m/s" is_input="True">375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
+        <altitude units="m" is_input="True">20000.0<!--altitude for sizing load case 1 (gust with minimum aircraft mass)--></altitude>
+      </lc1>
+      <lc2>
+        <U_gust units="m/s" is_input="True">15.25<!--gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)--></U_gust>
+        <Vc_EAS units="m/s" is_input="True">375.0<!--equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)--></Vc_EAS>
+        <altitude units="m" is_input="True">20000.0<!--altitude for sizing load case 2 (gust with maximum aircraft mass)--></altitude>
+      </lc2>
+    </load_case>
+    <propulsion>
+      <MTO_thrust units="N" is_input="True">117880.0<!--maximum thrust of one engine at sea level--></MTO_thrust>
+      <rubber_engine>
+        <bypass_ratio is_input="True">4.9<!--bypass ratio for rubber engine model--></bypass_ratio>
+        <delta_t4_climb is_input="True">0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_climb>
+        <delta_t4_cruise is_input="True">0.0<!--As it is a delta, unit is K or &#176;C, but is not specified to avoid OpenMDAO making unwanted conversion--></delta_t4_cruise>
+        <design_altitude units="m" is_input="True">10058.4<!--design altitude for rubber engine model--></design_altitude>
+        <maximum_mach is_input="True">0.85<!--maximum Mach number for rubber engine model--></maximum_mach>
+        <overall_pressure_ratio is_input="True">32.6<!--Overall pressure ratio for rubber engine model--></overall_pressure_ratio>
+        <turbine_inlet_temperature units="degK" is_input="True">1633.0<!--design turbine inlet temperature (T4) for rubber engine model--></turbine_inlet_temperature>
+      </rubber_engine>
+    </propulsion>
+    <mission>
+      <sizing>
+        <ISA_offset units="degK" is_input="True">0.0<!--Input defined by the mission.--></ISA_offset>
+        <TOW units="kg" is_input="False">78072.45659716826<!--Loaded fuel at beginning for mission "sizing"--></TOW>
+        <ZFW units="kg" is_input="False">57302.75321510128<!--Zero Fuel Weight for mission "sizing"--></ZFW>
+        <block_fuel units="kg" is_input="False">20769.703395958124<!--Loaded fuel at beginning for mission "sizing"_inp_data:mission:sizing:block_fuel--></block_fuel>
+        <consumed_fuel_before_input_weight units="kg" is_input="False">0.0<!--consumed fuel quantity before target mass defined for "sizing", if any (e.g. TakeOff Weight)--></consumed_fuel_before_input_weight>
+        <distance units="m" is_input="False">5093000.0<!--covered ground distance during mission "sizing"--></distance>
+        <duration units="s" is_input="False">19857.45794460585<!--duration of mission "sizing"--></duration>
+        <fuel units="kg" is_input="False">20769.703395958124<!--burned fuel during mission "sizing"--></fuel>
+        <needed_block_fuel units="kg" is_input="False">20769.703395958124<!--Needed fuel to complete mission "sizing", including reserve fuel--></needed_block_fuel>
+        <specific_burned_fuel units="1/nmi" is_input="False">0.0005550131846496211</specific_burned_fuel>
+        <cs25>
+          <load_factor_1 is_input="False">3.75</load_factor_1>
+          <load_factor_2 is_input="False">3.75</load_factor_2>
+          <sizing_load_1 units="kg" is_input="False">249254.59066519403</sizing_load_1>
+          <sizing_load_2 units="kg" is_input="False">262309.19884847995</sizing_load_2>
+        </cs25>
+        <global_reserve>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "global_reserve" in mission "sizing"--></distance>
+          <duration units="s" is_input="False">0.0<!--duration of route "global_reserve" in mission "sizing"--></duration>
+          <fuel units="kg" is_input="False">3438.1651920726144<!--burned fuel during route "global_reserve" in mission "sizing"--></fuel>
+        </global_reserve>
+        <landing>
+          <flap_angle units="deg" is_input="True">30.0</flap_angle>
+          <slat_angle units="deg" is_input="True">20.0</slat_angle>
+        </landing>
+        <main_route>
+          <distance units="m" is_input="False">5093000.0<!--covered ground distance during route "main_route" in mission "sizing"--></distance>
+          <duration units="s" is_input="False">19857.45794460585<!--duration of route "main_route" in mission "sizing"--></duration>
+          <fuel units="kg" is_input="False">17331.53820388551<!--burned fuel during route "main_route" in mission "sizing"--></fuel>
+          <climb>
+            <distance units="m" is_input="False">250000.0<!--covered ground distance during phase "climb" of route "main_route" in mission "sizing"--></distance>
+            <duration units="s" is_input="False">0.0<!--duration of phase "climb" of route "main_route" in mission "sizing"--></duration>
+            <fuel units="kg" is_input="False">2342.1736979150446<!--burned fuel during phase "climb" of route "main_route" in mission "sizing"--></fuel>
+          </climb>
+          <cruise>
+            <altitude units="ft" is_input="True">35000.0<!--Input defined by the mission.--></altitude>
+            <distance units="m" is_input="False">4593000.0<!--covered ground distance during phase "cruise" of route "main_route" in mission "sizing"--></distance>
+            <duration units="s" is_input="False">19857.45794460585<!--duration of phase "cruise" of route "main_route" in mission "sizing"--></duration>
+            <fuel units="kg" is_input="False">13749.75392651571<!--burned fuel during phase "cruise" of route "main_route" in mission "sizing"--></fuel>
+          </cruise>
+          <descent>
+            <distance units="m" is_input="False">250000.0<!--covered ground distance during phase "descent" of route "main_route" in mission "sizing"--></distance>
+            <duration units="s" is_input="False">0.0<!--duration of phase "descent" of route "main_route" in mission "sizing"--></duration>
+            <fuel units="kg" is_input="False">1239.6105794547548<!--burned fuel during phase "descent" of route "main_route" in mission "sizing"--></fuel>
+          </descent>
+        </main_route>
+        <start>
+          <altitude units="ft" is_input="True">0.0<!--Input defined by the mission.--></altitude>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "start" in mission "sizing"--></distance>
+          <duration units="s" is_input="False">0.0<!--duration of route "start" in mission "sizing"--></duration>
+          <fuel units="kg" is_input="False">0.0<!--burned fuel during route "start" in mission "sizing"--></fuel>
+          <true_airspeed units="m/s" is_input="True">0.0<!--Input defined by the mission.--></true_airspeed>
+        </start>
+        <takeoff>
+          <V2 units="m/s" is_input="True">0.0<!--Input defined by the mission.--></V2>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "takeoff" in mission "sizing"--></distance>
+          <duration units="min" is_input="True">0.0<!--Input defined by the mission.--></duration>
+          <fuel units="kg" is_input="True">0.0<!--Input defined by the mission.--></fuel>
+          <safety_altitude units="ft" is_input="True">35.0<!--Input defined by the mission.--></safety_altitude>
+        </takeoff>
+        <taxi_out>
+          <distance units="m" is_input="False">0.0<!--covered ground distance during route "taxi_out" in mission "sizing"--></distance>
+          <duration units="s" is_input="True">0.0<!--Input defined by the mission.--></duration>
+          <fuel units="kg" is_input="False">0.0<!--burned fuel during route "taxi_out" in mission "sizing"--></fuel>
+          <thrust_rate is_input="True">0.0<!--Input defined by the mission.--></thrust_rate>
+          <true_airspeed units="m/s" is_input="True">0.0<!--Input defined by the mission.--></true_airspeed>
+        </taxi_out>
+      </sizing>
+    </mission>
+    <weight>
+      <aircraft>
+        <MFW units="kg" is_input="False">20769.703382066982<!--maximum fuel weight--></MFW>
+        <MLW units="kg" is_input="False">67100.91840800736<!--maximum landing weight--></MLW>
+        <MTOW units="kg" is_input="False">78072.45659716826<!--maximum takeoff weight--></MTOW>
+        <MZFW units="kg" is_input="False">63302.75321510128<!--maximum zero fuel weight--></MZFW>
+        <OWE units="kg" is_input="False">43694.75321510128<!--Mass of crew--></OWE>
+        <additional_fuel_capacity units="kg" is_input="False">-1.389114186167717e-05<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
+        <max_payload units="kg" is_input="False">19608.0<!--max payload weight--></max_payload>
+        <payload units="kg" is_input="False">13608.0<!--_inp_data:weight:aircraft:payload--></payload>
+        <sizing_block_fuel units="kg" is_input="False">20769.703395958124<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>
+        <sizing_onboard_fuel_at_input_weight units="kg" is_input="False">20769.703395958124<!--_inp_data:weight:aircraft:sizing_onboard_fuel_at_input_weight--></sizing_onboard_fuel_at_input_weight>
+        <CG>
+          <aft>
+            <MAC_position is_input="False">0.3853309262304288<!--most aft X-position of center of gravity as ratio of mean aerodynamic chord--></MAC_position>
+            <x units="m" is_input="False">17.147365613150566<!--most aft X-position of aircraft center of gravity--></x>
+          </aft>
+        </CG>
+        <empty>
+          <CG>
+            <MAC_position is_input="False">0.3322843083339577<!--X-position of center of gravity as ratio of mean aerodynamic chord for empty aircraft--></MAC_position>
+          </CG>
+        </empty>
+        <load_cases>
+          <CG>
+            <MAC_position is_input="False">[[0.3149484255105222], [0.2383034517200329], [0.3353309262304288], [0.3323562004880358]]<maximum is_input="False">0.3353309262304288</maximum></MAC_position>
+          </CG>
+        </load_cases>
+      </aircraft>
+      <aircraft_empty>
+        <mass units="kg" is_input="False">43224.75318481118<!--mass of empty aircraft (=OWE - mass of crew)--></mass>
+        <CG>
+          <x units="m" is_input="False">16.935474728236237<!--X-position center of gravity of empty aircraft--></x>
+        </CG>
+      </aircraft_empty>
+      <airframe>
+        <mass units="kg" is_input="False">24436.583024874228<!--Mass of airframe--></mass>
+        <flight_controls>
+          <mass units="kg" is_input="False">779.6068608152888<!--Mass of airframe_inp_data:weight:airframe:flight_controls:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">19.55546859575235<!--flight controls (A4): X-position of center of gravity--></x>
+          </CG>
+        </flight_controls>
+        <fuselage>
+          <mass units="kg" is_input="False">8895.938459308234<!--Mass of airframe_inp_data:weight:airframe:fuselage:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">16.8783138<!--fuselage (A2): X-position of center of gravity--></x>
+          </CG>
+        </fuselage>
+        <horizontal_tail>
+          <mass units="kg" is_input="False">735.3156925257955<!--Mass of airframe_inp_data:weight:airframe:horizontal_tail:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">33.80080736331332<!--horizontal tail (A31): X-position of center of gravity--></x>
+          </CG>
+        </horizontal_tail>
+        <paint>
+          <mass units="kg" is_input="False">145.82686362599196<!--Mass of airframe_inp_data:weight:airframe:paint:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">0.0<!--paint (A7): X-position of center of gravity--></x>
+          </CG>
+        </paint>
+        <pylon>
+          <mass units="kg" is_input="False">1211.8837953053956<!--Mass of airframe_inp_data:weight:airframe:pylon:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">13.518823128038184<!--pylon (A6): X-position of center of gravity--></x>
+          </CG>
+        </pylon>
+        <vertical_tail>
+          <mass units="kg" is_input="False">582.301919021964<!--Mass of airframe_inp_data:weight:airframe:vertical_tail:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">33.23507785588395<!--vertical tail (A32): X-position of center of gravity--></x>
+          </CG>
+        </vertical_tail>
+        <wing>
+          <mass units="kg" is_input="False">9487.539576696334<!--Mass of airframe_inp_data:weight:airframe:wing:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">16.404972883622275<!--wing (A1): X-position of center of gravity--></x>
+          </CG>
+        </wing>
+        <landing_gear>
+          <front>
+            <mass units="kg" is_input="False">388.3472469678122<!--Mass of airframe_inp_data:weight:airframe:landing_gear:front:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">5.176347<!--front landing gear (A52): X-position of center of gravity--></x>
+            </CG>
+          </front>
+          <main>
+            <mass units="kg" is_input="False">2209.8226106074053<!--Mass of airframe_inp_data:weight:airframe:landing_gear:main:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">18.188323753424527<!--main landing gear (A51): X-position of center of gravity--></x>
+            </CG>
+          </main>
+        </landing_gear>
+      </airframe>
+      <crew>
+        <mass units="kg" is_input="False">470.0<!--Mass of crew_inp_data:weight:crew:mass--></mass>
+      </crew>
+      <furniture>
+        <mass units="kg" is_input="False">3112.5<!--Mass of aircraft furniture--></mass>
+        <food_water>
+          <mass units="kg" is_input="False">1312.5<!--Mass of aircraft furniture_inp_data:weight:furniture:food_water:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">29.403796000000007<!--food water (D3): X-position of center of gravity--></x>
+          </CG>
+        </food_water>
+        <passenger_seats>
+          <mass units="kg" is_input="False">1500.0<!--Mass of aircraft furniture_inp_data:weight:furniture:passenger_seats:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">16.616796<!--passenger seats (D2): X-position of center of gravity--></x>
+          </CG>
+        </passenger_seats>
+        <security_kit>
+          <mass units="kg" is_input="False">225.0<!--Mass of aircraft furniture_inp_data:weight:furniture:security_kit:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">16.616796<!--security kit (D4): X-position of center of gravity--></x>
+          </CG>
+        </security_kit>
+        <toilets>
+          <mass units="kg" is_input="False">75.0<!--Mass of aircraft furniture_inp_data:weight:furniture:toilets:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">16.616796<!--toilets (D5): X-position of center of gravity--></x>
+          </CG>
+        </toilets>
+      </furniture>
+      <propulsion>
+        <mass units="kg" is_input="False">7751.233737633545<!--Mass of the propulsion system--></mass>
+        <engine>
+          <mass units="kg" is_input="False">7161.3348000000005<!--Mass of the propulsion system_inp_data:weight:propulsion:engine:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">13.518823128038184<!--engine (B1): X-position of center of gravity--></x>
+          </CG>
+        </engine>
+        <fuel_lines>
+          <mass units="kg" is_input="False">467.2049757963101<!--Mass of the propulsion system_inp_data:weight:propulsion:fuel_lines:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">13.518823128038184<!--fuel lines (B2): X-position of center of gravity--></x>
+          </CG>
+        </fuel_lines>
+        <unconsumables>
+          <mass units="kg" is_input="False">122.69396183723444<!--Mass of the propulsion system_inp_data:weight:propulsion:unconsumables:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">13.518823128038184<!--unconsumables (B3): X-position of center of gravity--></x>
+          </CG>
+        </unconsumables>
+      </propulsion>
+      <systems>
+        <mass units="kg" is_input="False">7924.436452593506<!--Mass of aircraft systems--></mass>
+        <flight_kit>
+          <mass units="kg" is_input="False">45.0<!--Mass of aircraft systems_inp_data:weight:systems:flight_kit:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">7.468795999999999<!--flight kit (C6): X-position of center of gravity--></x>
+          </CG>
+        </flight_kit>
+        <navigation>
+          <mass units="kg" is_input="False">497.3313443369947<!--Mass of aircraft systems_inp_data:weight:systems:navigation:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">5.5214368<!--navigation (C3): X-position of center of gravity--></x>
+          </CG>
+        </navigation>
+        <transmission>
+          <mass units="kg" is_input="False">200.0<!--Mass of aircraft systems_inp_data:weight:systems:transmission:mass--></mass>
+          <CG>
+            <x units="m" is_input="False">18.753682<!--transmission (C4): X-position of center of gravity--></x>
+          </CG>
+        </transmission>
+        <life_support>
+          <air_conditioning>
+            <mass units="kg" is_input="False">942.4010810318936<!--Mass of aircraft systems_inp_data:weight:systems:life_support:air_conditioning:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.616796<!--air conditioning (C2): X-position of center of gravity--></x>
+            </CG>
+          </air_conditioning>
+          <cabin_lighting>
+            <mass units="kg" is_input="False">169.67684582876902<!--Mass of aircraft systems_inp_data:weight:systems:life_support:cabin_lighting:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.8783138<!--cabin lighting (C2): X-position of center of gravity--></x>
+            </CG>
+          </cabin_lighting>
+          <de-icing>
+            <mass units="kg" is_input="False">161.42126735746058<!--Mass of aircraft systems_inp_data:weight:systems:life_support:de-icing:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.007631830868988<!--de-icing (C2): X-position of center of gravity--></x>
+            </CG>
+          </de-icing>
+          <insulation>
+            <mass units="kg" is_input="False">2254.2780945822174<!--Mass of aircraft systems_inp_data:weight:systems:life_support:insulation:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.8783138<!--insulation (C21): X-position of center of gravity--></x>
+            </CG>
+          </insulation>
+          <oxygen>
+            <mass units="kg" is_input="False">284.1<!--Mass of aircraft systems_inp_data:weight:systems:life_support:oxygen:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.616796<!--oxygen (C21): X-position of center of gravity--></x>
+            </CG>
+          </oxygen>
+          <safety_equipment>
+            <mass units="kg" is_input="False">432.713348<!--Mass of aircraft systems_inp_data:weight:systems:life_support:safety_equipment:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.104086580704802<!--safety equipment (C21): X-position of center of gravity--></x>
+            </CG>
+          </safety_equipment>
+          <seats_crew_accommodation>
+            <mass units="kg" is_input="False">126.0<!--Mass of aircraft systems_inp_data:weight:systems:life_support:seats_crew_accommodation:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.616796<!--seats crew accommodation (C21): X-position of center of gravity--></x>
+            </CG>
+          </seats_crew_accommodation>
+        </life_support>
+        <operational>
+          <cargo_hold>
+            <mass units="kg" is_input="False">298.12413168616644<!--Mass of aircraft systems_inp_data:weight:systems:operational:cargo_hold:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">16.616796<!--cargo hold (C52): X-position of center of gravity--></x>
+            </CG>
+          </cargo_hold>
+          <radar>
+            <mass units="kg" is_input="False">100.0<!--Mass of aircraft systems_inp_data:weight:systems:operational:radar:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">0.7501472800000001<!--radar (C51): X-position of center of gravity--></x>
+            </CG>
+          </radar>
+        </operational>
+        <power>
+          <auxiliary_power_unit>
+            <mass units="kg" is_input="False">287.3784652052712<!--Mass of aircraft systems_inp_data:weight:systems:power:auxiliary_power_unit:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">35.6319958<!--power (C1): X-position of center of gravity--></x>
+            </CG>
+          </auxiliary_power_unit>
+          <electric_systems>
+            <mass units="kg" is_input="False">1349.17027668415<!--Mass of aircraft systems_inp_data:weight:systems:power:electric_systems:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">18.753682<!--power (C1): X-position of center of gravity--></x>
+            </CG>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass units="kg" is_input="False">776.8415978805841<!--Mass of aircraft systems_inp_data:weight:systems:power:hydraulic_systems:mass--></mass>
+            <CG>
+              <x units="m" is_input="False">18.753682<!--power (C1): X-position of center of gravity--></x>
+            </CG>
+          </hydraulic_systems>
+        </power>
+      </systems>
+      <fuel_tank>
+        <CG>
+          <x units="m" is_input="False">16.182499557827065<!--fuel tank: X-position of center of gravity--></x>
+        </CG>
+      </fuel_tank>
+      <payload>
+        <PAX>
+          <CG>
+            <x units="m" is_input="False">16.616796<!--passengers: X-position of center of gravity--></x>
+          </CG>
+        </PAX>
+        <front_fret>
+          <CG>
+            <x units="m" is_input="False">9.794134272764362<!--front fret: X-position of center of gravity--></x>
+          </CG>
+        </front_fret>
+        <rear_fret>
+          <CG>
+            <x units="m" is_input="False">20.275960518786448<!--rear fret: X-position of center of gravity--></x>
+          </CG>
+        </rear_fret>
+      </payload>
+    </weight>
+    <aerodynamics>
+      <aircraft>
+        <cruise>
+          <AoA units="rad" is_input="False">[-0.014976462284129976, -0.013478816055716979, -0.01198116982730398, -0.010483523598890983, -0.008985877370477987, -0.007488231142064988, -0.005990584913651992, -0.004492938685238992, -0.002995292456825996, -0.0014976462284129988, 0.0, 0.001497646228412997, 0.002995292456825994, 0.004492938685238992, 0.005990584913651992, 0.007488231142064986, 0.008985877370477985, 0.010483523598890983, 0.011981169827303979, 0.013478816055716977, 0.014976462284129976, 0.01647410851254297, 0.01797175474095597, 0.01946940096936897, 0.020967047197781963, 0.022464693426194962, 0.02396233965460796, 0.02545998588302096, 0.026957632111433958, 0.02845527833984695, 0.02995292456825995, 0.03145057079667295, 0.03294821702508595, 0.034445863253498944, 0.035943509481911946, 0.03744115571032494, 0.03893880193873794, 0.04043644816715094, 0.041934094395563934, 0.043431740623976936, 0.04492938685238993, 0.04642703308080293, 0.047924679309215915, 0.04942232553762892, 0.05091997176604191, 0.052417617994454914, 0.05391526422286791, 0.05541291045128091, 0.056910556679693906, 0.05840820290810691, 0.059905849136519904, 0.061403495364932906, 0.06290114159334591, 0.06439878782175891, 0.0658964340501719, 0.0673940802785849, 0.0688917265069979, 0.0703893727354109, 0.07188701896382388, 0.07338466519223688, 0.07488231142064988, 0.07637995764906289, 0.07787760387747587, 0.07937525010588888, 0.08087289633430188, 0.08237054256271488, 0.08386818879112787, 0.08536583501954087, 0.08686348124795387, 0.08836112747636687, 0.08985877370477986, 0.09135641993319285, 0.09285406616160585, 0.09435171239001885, 0.09584935861843184, 0.09734700484684485, 0.09884465107525785, 0.10034229730367085, 0.10183994353208384, 0.10333758976049684, 0.10483523598890984, 0.10633288221732284, 0.10783052844573583, 0.10932817467414883, 0.11082582090256182, 0.11232346713097482, 0.11382111335938781, 0.11531875958780081, 0.11681640581621382, 0.11831405204462682, 0.11981169827303981, 0.12130934450145281, 0.12280699072986581, 0.12430463695827881, 0.12580228318669182, 0.12729992941510482, 0.1287975756435178, 0.1302952218719308, 0.1317928681003438, 0.1332905143287568, 0.13478816055716977, 0.13628580678558277, 0.13778345301399578, 0.13928109924240878, 0.14077874547082178, 0.14227639169923478, 0.14377403792764779, 0.1452716841560608, 0.1467693303844738, 0.14826697661288676, 0.14976462284129977, 0.15126226906971277, 0.15275991529812577, 0.15425756152653874, 0.15575520775495175, 0.15725285398336475, 0.15875050021177772, 0.16024814644019073, 0.16174579266860373, 0.16324343889701673, 0.1647410851254297, 0.1662387313538427, 0.1677363775822557, 0.1692340238106687, 0.1707316700390817, 0.17222931626749471, 0.17372696249590772, 0.17522460872432072, 0.1767222549527337, 0.1782199011811467, 0.1797175474095597, 0.1812151936379727, 0.1827128398663857, 0.1842104860947987, 0.1857081323232117, 0.1872057785516247, 0.1887034247800377, 0.19020107100845068, 0.19169871723686369, 0.1931963634652767, 0.1946940096936897, 0.19619165592210266, 0.19768930215051567, 0.19918694837892867, 0.20068459460734164, 0.20218224083575465, 0.20367988706416765, 0.20517753329258065, 0.20667517952099365, 0.20817282574940665]</AoA>
+          <CD is_input="False">[0.020872038573252844, 0.02087511043992142, 0.020883920318653347, 0.020898572437546076, 0.020919171024697054, 0.020945820308203727, 0.02097862451616354, 0.021017687876673945, 0.021063114617832387, 0.021115008967736302, 0.02117347515448315, 0.021238617406170373, 0.02131053995089542, 0.02138934701675574, 0.02147514283184877, 0.021568031624271962, 0.021668117622122764, 0.021775505053498623, 0.02189029814649698, 0.022012601129215287, 0.022142518229750996, 0.022280153676201543, 0.02242561169666438, 0.02257899651923695, 0.02274041237201671, 0.022909963483101092, 0.023087754080587556, 0.023273888392573543, 0.023468470647156493, 0.023671605072433863, 0.023883395896503096, 0.024103947347461643, 0.024333363653406943, 0.024571749042436444, 0.024819207742647603, 0.025075843982137854, 0.02534389127047732, 0.02562560967984396, 0.0259211836792014, 0.026230853091042308, 0.02655491593792194, 0.02689373254402931, 0.027247731013484953, 0.027617414249616664, 0.02800336872836543, 0.028406275296204205, 0.028826922330900055, 0.029266221685023013, 0.029725227930882135, 0.030205161545989158, 0.030707436825752714, 0.031233695491841858, 0.03178584718927613, 0.032366118343858705, 0.03297711119808434, 0.03362187527593867, 0.03430399406776387, 0.035027690404606515, 0.035797954844348355, 0.03662070246716946, 0.03750296483694297, 0.038453125607298355, 0.03948121043889723, 0.04059924468099626, 0.04182169582863246, 0.04316602232229108, 0.04465335610445342, 0.04630935387317915, 0.048165261684188485, 0.05025925011798357, 0.0526380935297635, 0.05535928810553943, 0.05849373110890153, 0.06212911988378553, 0.06637427663475563, 0.07136466742534821, 0.0772694661655225, 0.0843006232603963, 0.09272454304996583, 0.10287716634243924, 0.11518351073125443, 0.1301830644392693, 0.14856288979099933, 0.17120091200430143, 0.19922270536270795, 0.23407622118723317, 0.27763043971356294, 0.3323060223776668, 0.40124890231691784, 0.4885616718345275, 0.5553484332848796, 0.5562853597675244, 0.5572374047910025, 0.5582046725834117, 0.5591872673728493, 0.5601852933874129, 0.5611988548551998, 0.5622280560043075, 0.5632730010628335, 0.5643337942588751, 0.5654105398205298, 0.5665033419758951, 0.5676123049530686, 0.5687375329801475, 0.5698791302852292, 0.5710372010964114, 0.5722118496417913, 0.5734031801494665, 0.5746112968475344, 0.5758363039640926, 0.5770783057272382, 0.5783374063650689, 0.5796137101056822, 0.5809073211771754, 0.5822183438076458, 0.5835468822251914, 0.5848930406579089, 0.5862569233338963, 0.587638634481251, 0.5890382783280702, 0.5904559591024514, 0.5918917810324922, 0.5933458483462899, 0.594818265271942, 0.5963091360375461, 0.5978185648711993, 0.5993466560009995, 0.6008935136550437, 0.6024592420614295, 0.6040439454482546, 0.6056477280436161, 0.6072706940756116, 0.6089129477723385, 0.6105745933618942, 0.6122557350723765, 0.6139564771318823, 0.6156769237685096, 0.6174171792103552, 0.6191773476855171, 0.6209575334220927, 0.6227578406481791, 0.624578373591874, 0.6264192364812747, 0.6282805335444789, 0.6301623690095838, 0.632064847104687, 0.6339880720578858, 0.6359321480972777, 0.6378971794509604, 0.6398832703470309]<!--Input defined by the mission.--><compressibility is_input="False">[0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.001025528490322346, 0.0010276577717950224, 0.0010340721788208763, 0.001044851952266096, 0.001060132686525893, 0.001080108176058095, 0.0011050345169542509, 0.0011352355852374634, 0.0011711100561380642, 0.0012131401774996004, 0.0012619025676975858, 0.0013180813764016425, 0.0013824842280843375, 0.0014560614669572966, 0.0015399293424348073, 0.001635397921828059, 0.0017440046987086473, 0.0018675550899986708, 0.0020081712934038637, 0.002168351323321527, 0.0023510404756398656, 0.002559718012603585, 0.002798502537161831, 0.0030722803790988957, 0.0033868623904974157, 0.0037491759071330683, 0.004167500354537878, 0.00465175716527602, 0.00521386746050672, 0.005868194507169543, 0.006632092517652276, 0.007526589206338793, 0.008577237043191297, 0.009815177855832573, 0.01127847799666732, 0.01301380759279717, 0.015078558602135845, 0.017543524060176063, 0.02049629708275611, 0.02404559564634274, 0.02832678158637488, 0.033508924584714314, 0.03980387081838143, 0.047477920399274925, 0.05686690990750556, 0.06839575270841378, 0.08260383279676002, 0.10017810826896235, 0.1219964001147802, 0.1491841783896485, 0.18318929018648408, 0.2258806115128753, 0.27967869957669433, 0.34772938328721664, 0.43413515071955644, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]<!--increment of drag coefficient due to compressibility effects (shock waves) w.r.t. data:aerodynamics:aircraft:cruise:CL--></compressibility><trim is_input="False">[0.0, 5.89e-06, 1.178e-05, 1.767e-05, 2.356e-05, 2.945e-05, 3.534e-05, 4.123e-05, 4.712e-05, 5.3009999999999996e-05, 5.89e-05, 6.479e-05, 7.068e-05, 7.657000000000001e-05, 8.246e-05, 8.834999999999999e-05, 9.424e-05, 0.00010013, 0.00010601999999999999, 0.00011191, 0.0001178, 0.00012369, 0.00012958, 0.00013547, 0.00014136, 0.00014725, 0.00015314000000000001, 0.00015903, 0.00016492, 0.00017081, 0.00017669999999999999, 0.00018259, 0.00018848, 0.00019437, 0.00020026, 0.00020615000000000002, 0.00021203999999999998, 0.00021793, 0.00022382, 0.00022971000000000002, 0.0002356, 0.00024149000000000002, 0.00024738, 0.00025327, 0.00025916, 0.00026505, 0.00027094, 0.00027683000000000004, 0.00028272, 0.00028861, 0.0002945, 0.00030039, 0.00030628000000000003, 0.00031217, 0.00031806, 0.00032395000000000004, 0.00032984, 0.00033573, 0.00034162, 0.00034751, 0.00035339999999999997, 0.00035929, 0.00036518, 0.00037107, 0.00037696, 0.00038285, 0.00038874, 0.00039463000000000004, 0.00040052, 0.00040641000000000006, 0.00041230000000000005, 0.00041819, 0.00042407999999999996, 0.00042997, 0.00043586, 0.00044175, 0.00044764, 0.00045353, 0.00045942000000000004, 0.00046531000000000003, 0.0004712, 0.00047709000000000006, 0.00048298000000000004, 0.0004888700000000001, 0.00049476, 0.0005006499999999999, 0.00050654, 0.00051243, 0.00051832, 0.00052421, 0.0005301, 0.00053599, 0.00054188, 0.00054777, 0.0005536600000000001, 0.00055955, 0.00056544, 0.00057133, 0.00057722, 0.00058311, 0.000589, 0.00059489, 0.00060078, 0.00060667, 0.0006125600000000001, 0.00061845, 0.00062434, 0.0006302300000000001, 0.00063612, 0.00064201, 0.0006479000000000001, 0.00065379, 0.00065968, 0.0006655700000000001, 0.00067146, 0.0006773500000000001, 0.00068324, 0.0006891299999999999, 0.00069502, 0.00070091, 0.0007067999999999999, 0.00071269, 0.00071858, 0.00072447, 0.00073036, 0.00073625, 0.00074214, 0.00074803, 0.00075392, 0.00075981, 0.0007657, 0.0007715900000000001, 0.00077748, 0.00078337, 0.0007892600000000001, 0.0007951500000000001, 0.00080104, 0.0008069300000000001, 0.0008128200000000001, 0.00081871, 0.0008246000000000001, 0.0008304899999999999, 0.00083638, 0.00084227, 0.0008481599999999999, 0.00085405, 0.00085994, 0.0008658299999999999, 0.00087172, 0.00087761]<!--increment of drag coefficient due to aircraft trim w.r.t. data:aerodynamics:aircraft:cruise:CL--></trim></CD>
+          <CD0 is_input="False">[0.019846510082930497, 0.019840045901697075, 0.019832027636723013, 0.019822559516105755, 0.019811745767942753, 0.01979969062033145, 0.019786498301369297, 0.019772273039153736, 0.01975711906178222, 0.019741140597352182, 0.019724441873961083, 0.019707127119706364, 0.019689300562685478, 0.01967106643099586, 0.01965252895273497, 0.019633792356000244, 0.01961496086888913, 0.01959613871949908, 0.01957743013592754, 0.01955893934627195, 0.019540770578629765, 0.01952302806109843, 0.019505816021775386, 0.01948923868875808, 0.019473400290143973, 0.01945840505403049, 0.019444357208515096, 0.01943136098169523, 0.019419520601668336, 0.019408940296531865, 0.019399724294383264, 0.01939197682331998, 0.019385802111439455, 0.01938130438683914, 0.019378587877616482, 0.01937775681186893, 0.01937891541769392, 0.019382167923188906, 0.01938761855645134, 0.01939537154557866, 0.01940553111866831, 0.019418201503817754, 0.01943348692912442, 0.019451491622685765, 0.019472319812599236, 0.019496075726962273, 0.01952286359387232, 0.019552787641426844, 0.01958595209772327, 0.01962246119085905, 0.01966241914893164, 0.019705930200038472, 0.019753098572277007, 0.019804028493744682, 0.01985882419253895, 0.01991758989675725, 0.019980429834497042, 0.020047448233855757, 0.020118749322930854, 0.02019443732981977, 0.02027461648261996, 0.020359391009428865, 0.020448865138343937, 0.020543143097462618, 0.020642329114882355, 0.0207465274187006, 0.020855842237014796, 0.020970377797922386, 0.02109023832952082, 0.021215528059907545, 0.021346351217180013, 0.02148281202943566, 0.021625014724771942, 0.021773063531286302, 0.021927062677076184, 0.022087116390239036, 0.02225332889887231, 0.022425804431073445, 0.022604647214939894, 0.022789961478569102, 0.02298185145005852, 0.023180421357505584, 0.023385775429007744, 0.023598017892662457, 0.023817252976567154, 0.02404358490881929, 0.024277117917516317, 0.02451795623075567, 0.024766204076634806, 0.025021965683251168, 0.025285345278702204, 0.02555644709108535, 0.02583537534849807, 0.026122234279037804, 0.026417128110801998, 0.02672016107188809, 0.02703143739039354, 0.02735106129441578, 0.027679137012052282, 0.028015768771400468, 0.0283610608005578, 0.028715117327621702, 0.02907804258068965, 0.029449940787859074, 0.029830916177227433, 0.030221072976892152, 0.0306205154149507, 0.031029347719500517, 0.031447674118639045, 0.03187559884046372, 0.03231322611307202, 0.03276066016456136, 0.033218005223029215, 0.033685365516573015, 0.03416284527329019, 0.03465054872127822, 0.035148580088634536, 0.03565704360345658, 0.0361760434938418, 0.03670568398788766, 0.03724606931369161, 0.037797303699351054, 0.038359491372963475, 0.03893273656262631, 0.039517143496437014, 0.04011281640249302, 0.040719859508891766, 0.04133837704373072, 0.041968473235107336, 0.04261025231111904, 0.04326381849986328, 0.04392927602943751, 0.044606729127939185, 0.04529628202346573, 0.04599803894411461, 0.046712104117983266, 0.04743858177316913, 0.04817757613776968, 0.04892919143988233, 0.04969353190760456, 0.05047070176903379, 0.051260805252267456, 0.05206394658540302, 0.052880229996537964, 0.05370975971376969, 0.05455263996519567, 0.05540897497891331, 0.05627886898302012, 0.0571624262056135, 0.05805975087479091]<!--profile drag coefficient for whole aircraft in cruise conditions w.r.t. data:aerodynamics:aircraft:cruise:CL--><clean is_input="False">[0.017935330427695784, 0.01792948873432594, 0.017922242612404975, 0.017913686253070753, 0.017903913847461157, 0.01789301958671406, 0.017881097661967337, 0.01786824226435886, 0.01785454758502651, 0.017840107815108152, 0.01782501714574167, 0.017809369768064937, 0.01779325987321583, 0.017776781652332214, 0.017760029296551978, 0.017743096997012986, 0.017726078944853115, 0.017709069331210244, 0.017692162347222245, 0.017675452184026993, 0.017659033032762363, 0.017642999084566232, 0.01762744453057647, 0.017612463561930955, 0.017598150369767567, 0.01758459914522417, 0.017571904079438646, 0.01756015936354887, 0.017549459188692714, 0.017539897746008056, 0.01753156922663277, 0.01752456782170473, 0.01751898772236181, 0.017514923119741885, 0.017512468204982833, 0.017511717169222528, 0.017512764203598843, 0.01751570349924965, 0.017520629247312833, 0.01752763563892626, 0.017536816865227803, 0.017548267117355347, 0.017562080586446756, 0.017578351463639914, 0.017597173940072694, 0.017618642206882966, 0.017642850455208605, 0.017669892876187497, 0.017699863660957504, 0.017732857000656504, 0.017768967086422376, 0.01780828810939299, 0.017850914260706226, 0.017896939731499955, 0.017946458712912054, 0.017999565396080396, 0.01805635397214286, 0.018116918632237314, 0.01818135356750164, 0.018249752969073708, 0.018322211028091395, 0.018398821935692575, 0.018479679883015125, 0.01856487906119692, 0.018654513661375827, 0.018748677874689732, 0.018847465892276507, 0.018950971905274023, 0.019059290104820156, 0.01917251468205278, 0.019290739828109776, 0.019414059734129012, 0.019542568591248366, 0.019676360590605714, 0.019815529923338928, 0.019960170780585883, 0.02011037735348446, 0.020266243833172524, 0.020427864410787956, 0.020595333277468632, 0.020768744624352426, 0.02094819264257721, 0.02113377152328086, 0.021325575457601255, 0.02152369863667626, 0.02172823525164376, 0.02193927949364163, 0.022156925553807733, 0.02238126762327996, 0.022612399893196175, 0.022850416554694258, 0.023095411798912075, 0.023347479816987517, 0.023606714800058447, 0.023873210939262743, 0.024147062425738275, 0.024428363450622926, 0.02471720820505456, 0.025013690880171073, 0.02531790566711032, 0.025629946757010184, 0.025949908341008528, 0.026277884610243246, 0.026613969755852198, 0.026958257968973276, 0.02731084344074433, 0.027671820362303257, 0.028041282924787927, 0.02841932531933621, 0.028806041737085966, 0.029201526369175102, 0.029605873406741475, 0.030019177040922964, 0.030441531462857444, 0.030873030863682777, 0.031313769434536856, 0.03176384136655754, 0.03222334085088272, 0.032692362078650256, 0.03317099924099804, 0.033659346529063945, 0.034157498133985824, 0.03466554824690157, 0.03518359105894906, 0.035711720761266164, 0.036250031544990756, 0.03679861760126069, 0.03735757312121388, 0.03792699229598818, 0.03850696931672147, 0.03909759837455161, 0.0396989736606165, 0.040311189366054004, 0.04093433968200199, 0.04156851879959834, 0.04221382090998093, 0.04287034020428762, 0.04353817087365631, 0.044217407109224845, 0.04490814310213114, 0.04561047304351303, 0.0463244911245084, 0.047050291536255125, 0.04778796846989111, 0.048537616116554196, 0.049299328667382285, 0.0500732003135132, 0.05085932524608488, 0.05165779765623517, 0.05246871173510193]<!--like data:aerodynamics:aircraft:cruise:CD0 but without parasitic drag--></clean><parasitic is_input="False">[0.0019111796552347127, 0.0019105571673711345, 0.0019097850243180378, 0.001908873263035002, 0.001907831920481596, 0.0019066710336173923, 0.00190540063940196, 0.001904030774794875, 0.00190257147675571, 0.0019010327822440304, 0.001899424728219412, 0.0018977573516414277, 0.0018960406894696497, 0.001894284778663647, 0.0018924996561829922, 0.0018906953589872579, 0.0018888819240360163, 0.0018870693882888367, 0.001885267788705295, 0.0018834871622449567, 0.0018817375458674013, 0.0018800289765321977, 0.001878371491198915, 0.0018767751268271259, 0.001875249920376406, 0.001873805908806321, 0.0018724531290764505, 0.00187120161814636, 0.0018700614129756217, 0.0018690425505238084, 0.001868155067750496, 0.00186740900161525, 0.0018668143890776465, 0.0018663812670972543, 0.0018661196726336496, 0.0018660396426464013, 0.0018661512140950784, 0.001866464423939257, 0.001866989309138506, 0.0018677359066524013, 0.0018687142534405086, 0.0018699343864624074, 0.001871406342677663, 0.0018731401590458517, 0.0018751458725265423, 0.0018774335200793073, 0.0018800131386637157, 0.0018828947652393471, 0.001886088436765767, 0.0018896041902025477, 0.001893452062509262, 0.0018976420906454822, 0.0019021843115707808, 0.001907088762244727, 0.0019123654796268964, 0.001918024500676855, 0.001924075862354182, 0.0019305296016184428, 0.0019373957554292137, 0.0019446843607460636, 0.001952405454528565, 0.00196056907373629, 0.001969185255328812, 0.001978264036265699, 0.001987815453506528, 0.001997849544010867, 0.002008376344738289, 0.0020194058926483634, 0.0020309482247006655, 0.0020430133778547646, 0.0020556113890702367, 0.0020687522953066473, 0.002082446133523576, 0.002096702940680588, 0.002111532753737256, 0.0021269456096531525, 0.00214295154538785, 0.002159560597900921, 0.002176782804151938, 0.00219462820110047, 0.002213106825706093, 0.0022322287149283727, 0.002252003905726885, 0.002272442435061202, 0.002293554339890893, 0.0023153496571755305, 0.002337838423874687, 0.0023610306769479353, 0.0023849364533548474, 0.0024095657900549926, 0.0024349287240079467, 0.0024610352921732755, 0.0024878955315105547, 0.002515519478979357, 0.0025439171715392547, 0.0025730986461498136, 0.002603073939770613, 0.0026338530893612183, 0.002665446131881209, 0.0026978631042901477, 0.0027311140435476167, 0.0027652089866131747, 0.002800157970446405, 0.002835971032006876, 0.002872658208254157, 0.002910229536147821, 0.002948695052647443, 0.0029880647947125895, 0.003028348799302836, 0.0030695571033777513, 0.0031116997438969153, 0.0031547867578198864, 0.003198828182106251, 0.003243834053715571, 0.003289814409607416, 0.003336779286741365, 0.0033847387220769937, 0.003433702752573861, 0.0034836814151915432, 0.003534684746889623, 0.003586722784627662, 0.0036398055653652298, 0.003693943126061902, 0.003749145503677248, 0.0038054227351708506, 0.0038627848575022647, 0.003921241907631073, 0.003980803922516846, 0.0040414809391191575, 0.004103282994397571, 0.004166220125311669, 0.004230302368821014, 0.004295539761885181, 0.00436194234146374, 0.004429520144516273, 0.004498283208002336, 0.004568241568881512, 0.004639405264113369, 0.004711784330657484, 0.004785388805473419, 0.004860228725520756, 0.0049363141277590575, 0.005013655049147893, 0.005092261526646852, 0.005172143597215496, 0.005253311297813389, 0.0053357746654001115, 0.005419543736935241, 0.005504628549378332, 0.005591039139688975]<!--estimated parasitic drag for whole aircraft in cruise conditions (no high-lift) w.r.t. data:aerodynamics:aircraft:low_speed:CL--></parasitic></CD0>
+          <CL is_input="False">[0.0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19, 0.2, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.3, 0.31, 0.32, 0.33, 0.34, 0.35000000000000003, 0.36, 0.37, 0.38, 0.39, 0.4, 0.41000000000000003, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47000000000000003, 0.48, 0.49, 0.5, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.5700000000000001, 0.58, 0.59, 0.6, 0.61, 0.62, 0.63, 0.64, 0.65, 0.66, 0.67, 0.68, 0.6900000000000001, 0.7000000000000001, 0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79, 0.8, 0.81, 0.8200000000000001, 0.8300000000000001, 0.84, 0.85, 0.86, 0.87, 0.88, 0.89, 0.9, 0.91, 0.92, 0.93, 0.9400000000000001, 0.9500000000000001, 0.96, 0.97, 0.98, 0.99, 1.0, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08, 1.09, 1.1, 1.11, 1.12, 1.1300000000000001, 1.1400000000000001, 1.1500000000000001, 1.16, 1.17, 1.18, 1.19, 1.2, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26, 1.27, 1.28, 1.29, 1.3, 1.31, 1.32, 1.33, 1.34, 1.35, 1.36, 1.37, 1.3800000000000001, 1.3900000000000001, 1.4000000000000001, 1.41, 1.42, 1.43, 1.44, 1.45, 1.46, 1.47, 1.48, 1.49]<!--Input defined by the mission.--></CL>
+          <CL0 is_input="True">0.1</CL0>
+          <CL_alpha units="1/rad" is_input="False">6.677144315047382<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
+          <L_D_max is_input="False">16.375148677677767<!--max lift/drag ratio in cruise conditions--></L_D_max>
+          <induced_drag_coefficient is_input="False">0.041908596574680546<!--multiply squared lift coefficient by this coefficient to get induced drag coefficient--></induced_drag_coefficient>
+          <optimal_CD is_input="False">0.032366118343858705<!--drag coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CD>
+          <optimal_CL is_input="False">0.53<!--lift coefficient at maximum lift/drag ratio in cruise conditions--></optimal_CL>
+          <oswald_coefficient is_input="False">0.7951098332461126<!--Oswald coefficient for cruise conditions--></oswald_coefficient>
+        </cruise>
+        <landing>
+          <CL_max is_input="False">2.806181966182601<!--maximum lift coefficient in landing conditions--></CL_max>
+          <CL_max_clean is_input="False">1.5824133961659907<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
+          <CL_max_clean_2D is_input="True">1.94<!--maximum lift coefficient of 2D average profile in landing conditions without high-lift devices--></CL_max_clean_2D>
+          <additional_CL_capacity is_input="False">0.1265355286062495<!--at landing, is equal to (maximum lift coefficient)-(maximum required lift coefficient)--></additional_CL_capacity>
+          <mach is_input="False">0.19455259748464468<!--considered Mach number for landing phase--></mach>
+        </landing>
+      </aircraft>
+      <cruise>
+        <neutral_point>
+          <x is_input="False">0.4182307967922947<!--X-position of neutral point - X-position of aircraft nose--></x>
+        </neutral_point>
+      </cruise>
+      <fuselage>
+        <cruise>
+          <CD0 is_input="False">[0.007075381149200346, 0.007056205921020434, 0.007037199946110106, 0.007018363224469361, 0.006999695756098201, 0.006981197540996624, 0.006962868579164631, 0.006944708870602221, 0.006926718415309396, 0.006908897213286154, 0.0068912452645324964, 0.0068737625690484215, 0.006856449126833931, 0.006839304937889024, 0.006822330002213701, 0.0068055243198079625, 0.0067888878906718075, 0.006772420714805235, 0.006756122792208248, 0.0067399941228808435, 0.006724034706823022, 0.006708244544034786, 0.006692623634516133, 0.006677171978267064, 0.006661889575287579, 0.0066467764255776765, 0.006631832529137359, 0.006617057885966625, 0.006602452496065474, 0.006588016359433908, 0.006573749476071925, 0.006559651845979526, 0.006545723469156711, 0.006531964345603479, 0.006518374475319832, 0.0065049538583057676, 0.006491702494561287, 0.00647862038408639, 0.006465707526881078, 0.0064529639229453485, 0.0064403895722792035, 0.006427984474882642, 0.0064157486307556645, 0.00640368203989827, 0.00639178470231046, 0.006380056617992234, 0.006368497786943591, 0.006357108209164532, 0.006345887884655057, 0.006334836813415166, 0.006323954995444858, 0.006313242430744134, 0.006302699119312994, 0.006292325061151438, 0.0062821202562594654, 0.006272084704637076, 0.006262218406284271, 0.00625252136120105, 0.006242993569387413, 0.006233635030843359, 0.006224445745568888, 0.006215425713564002, 0.0062065749348287, 0.006197893409362981, 0.006189381137166846, 0.006181038118240295, 0.006172864352583327, 0.006164859840195944, 0.006157024581078144, 0.006149358575229928, 0.006141861822651295, 0.006134534323342247, 0.006127376077302782, 0.0061203870845329, 0.006113567345032603, 0.006106916858801889, 0.00610043562584076, 0.006094123646149214, 0.006087980919727252, 0.006082007446574873, 0.006076203226692078, 0.006070568260078867, 0.00606510254673524, 0.006059806086661196, 0.006054678879856736, 0.00604972092632186, 0.006044932226056568, 0.006040312779060859, 0.006035862585334735, 0.006031581644878194, 0.006027469957691237, 0.006023527523773863, 0.006019754343126073, 0.006016150415747867, 0.006012715741639245, 0.006009450320800207, 0.006006354153230752, 0.006003427238930882, 0.006000669577900594, 0.005998081170139891, 0.005995662015648771, 0.005993412114427235, 0.005991331466475283, 0.005989420071792915, 0.00598767793038013, 0.0059861050422369295, 0.005984701407363313, 0.005983467025759279, 0.00598240189742483, 0.005981506022359964, 0.0059807794005646816, 0.005980222032038984, 0.005979833916782869, 0.005979615054796338, 0.005979565446079391, 0.005979685090632028, 0.0059799739884542485, 0.005980432139546053, 0.005981059543907441, 0.005981856201538413, 0.005982822112438968, 0.005983957276609108, 0.005985261694048831, 0.005986735364758138, 0.005988378288737029, 0.005990190465985503, 0.005992171896503561, 0.005994322580291203, 0.005996642517348429, 0.005999131707675238, 0.006001790151271631, 0.006004617848137608, 0.0060076147982731695, 0.0060107810016783135, 0.006014116458353041, 0.006017621168297353, 0.006021295131511249, 0.006025138347994729, 0.006029150817747792, 0.0060333325407704395, 0.00603768351706267, 0.006042203746624485, 0.006046893229455883, 0.006051751965556865, 0.0060567799549274305, 0.006061977197567581, 0.006067343693477314, 0.006072879442656631, 0.006078584445105532, 0.006084458700824016]<!--profile drag coefficient for fuselage w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
+          <CnBeta is_input="False">-0.10014029744407044<!--derivative of yawing moment against sideslip angle for fuselage in cruise conditions--></CnBeta>
+        </cruise>
+      </fuselage>
+      <high_lift_devices>
+        <landing>
+          <CD is_input="False">0.03309219200000092<!--increment of CD due to high-lift devices for landing phase--></CD>
+          <CL is_input="False">1.2237685700166105<!--increment of CL due to high-lift devices for landing phase--></CL>
+        </landing>
+      </high_lift_devices>
+      <horizontal_tail>
+        <cruise>
+          <CD0 is_input="False">0.0016917239383164486<!--profile drag coefficient for horizontal tail in cruise conditions--></CD0>
+          <CL_alpha units="1/rad" is_input="False">3.4698175649817595<!--derivative of lift coefficient of horizontal tail with respect to local angle of attack in cruise conditions--></CL_alpha>
+        </cruise>
+      </horizontal_tail>
+      <nacelles>
+        <cruise>
+          <CD0 is_input="False">0.0015387600282942534<!--profile drag coefficient for nacelles in cruise conditions--></CD0>
+        </cruise>
+      </nacelles>
+      <pylons>
+        <cruise>
+          <CD0 is_input="False">0.0003249180163983077<!--profile drag coefficient for pylons in cruise conditions--></CD0>
+        </cruise>
+      </pylons>
+      <vertical_tail>
+        <cruise>
+          <CD0 is_input="False">0.001300013266319344<!--profile drag coefficient for vertical tail in cruise conditions--></CD0>
+          <CL_alpha units="1/rad" is_input="False">2.546156443275808<!--derivative of lift coefficient of horizontal tail with respect to local "angle of attack" in cruise conditions--></CL_alpha>
+          <CnBeta units="m**2" is_input="False">0.24058703344407045<!--derivative of yawing moment against sideslip angle for vertical tail in cruise conditions--></CnBeta>
+        </cruise>
+      </vertical_tail>
+      <wing>
+        <cruise>
+          <CD0 is_input="False">[0.006004534029167089, 0.006017867563977157, 0.006029627416966518, 0.006039907779273041, 0.006048802842034605, 0.006056406796389085, 0.006062813833474354, 0.006068118144428288, 0.0060724139203887605, 0.006075795352493647, 0.006078356631880825, 0.006080191949688165, 0.006081395497053546, 0.0060820614651148405, 0.006082284045009924, 0.006082157427876672, 0.006081775804852958, 0.006081233367076657, 0.006080624305685647, 0.006080042811817799, 0.00607958307661099, 0.006079339291203093, 0.006079405646731986, 0.006079876334335541, 0.006080845545151636, 0.006082407470318143, 0.0060846563009729375, 0.006087686228253894, 0.00609159144329889, 0.006096466137245798, 0.0061024045012324935, 0.006109500726396852, 0.006117849003876748, 0.006127543524810056, 0.006138678480334651, 0.006151348061588409, 0.006165646459709203, 0.006181667865834909, 0.006199506471103402, 0.006219256466652558, 0.0062410120436202495, 0.0062648673931443525, 0.006290916706362742, 0.0063192541744132935, 0.006349973988433882, 0.0063831703395623805, 0.006418937418936664, 0.0064573694176946125, 0.006498560526974094, 0.0065426049379129865, 0.0065895968416491675, 0.006639630429320506, 0.0066927998920648804, 0.006749199421020166, 0.006808923207324238, 0.006872065442114969, 0.006938720316530237, 0.0070089820217079145, 0.007082944748785876, 0.007160702688901998, 0.007242350033194156, 0.007327980972800222, 0.007417689698858074, 0.007511570402505585, 0.00760971727488063, 0.007712224507121087, 0.007819186290364826, 0.007930696815749726, 0.008046850274413661, 0.008167740857494502, 0.008293462756130129, 0.008424110161458413, 0.008559777264617232, 0.008700558256744461, 0.008846547328977973, 0.008997838672455643, 0.009154526478315347, 0.009316704937694958, 0.009484468241732354, 0.009657910581565409, 0.009837126148331998, 0.010022209133169993, 0.01021325372721727, 0.010410354121611707, 0.010613604507491173, 0.01082309907599355, 0.01103893201825671, 0.011261197525418522, 0.011489989788616872, 0.01172540299898963, 0.011967531347674669, 0.012216469025809862, 0.012472310224533094, 0.012735149134982228, 0.013005079948295147, 0.013282196855609716, 0.013566594048063822, 0.013858365716795329, 0.014157606052942126, 0.014464409247642078, 0.01477886949203306, 0.01510108097725294, 0.015431137894439612, 0.015769134434730932, 0.016115164789264794, 0.016469323149179052, 0.016831703705611593, 0.017202400649700297, 0.017581508172583027, 0.017969120465397653, 0.01836533171928207, 0.01877023612537414, 0.019183927874811744, 0.019606501158732755, 0.020038050168275034, 0.020478669094576477, 0.02092845212877494, 0.021387493462008314, 0.021855887285414464, 0.022333727790131278, 0.022821109167296624, 0.02331812560804836, 0.023824871303524384, 0.02434144044486257, 0.024867927223200775, 0.02540442582967689, 0.02595103045542877, 0.026507835291594315, 0.02707493452931139, 0.027652422359717873, 0.028240392973951617, 0.02883894056315053, 0.029448159318452478, 0.030068143430995314, 0.03069898709191694, 0.031340784492355216, 0.031993629823448014, 0.03265761727633322, 0.033332841042148696, 0.034019395312032345, 0.034717374277122, 0.03542687212855555, 0.036147983057470884, 0.03688080125500589, 0.03762542091229841, 0.03838193622048634, 0.03915044137070753, 0.03993103055409989, 0.04072379796180128, 0.041528837784949556]<!--profile drag coefficient for wing w.r.t. data:aerodynamics:aircraft:cruise:CL--></CD0>
+          <reynolds is_input="False">6124998.624249204<!--Reynolds number based on wing mean aerodynamic chord in cruise conditions--></reynolds>
+        </cruise>
+        <landing>
+          <reynolds is_input="False">16972281.759543926<!--Reynolds number based on wing mean aerodynamic chord in landing conditions--></reynolds>
+        </landing>
+      </wing>
+    </aerodynamics>
+  </data>
+  <settings>
+    <geometry>
+      <horizontal_tail>
+        <position_ratio_on_VTP is_input="True">0.15<!--(applies only for T-tails) distance between HTP root leadingedge and VTP tip leading edge divided by VTP tip chord--></position_ratio_on_VTP>
+        <position_ratio_on_fuselage is_input="True">0.91<!--(does not apply for T-tails) distance to aircraft nose of 25% MAC of horizontal tail divided by fuselage length--></position_ratio_on_fuselage>
+      </horizontal_tail>
+      <vertical_tail>
+        <position_ratio_on_fuselage is_input="True">0.88<!--distance to aircraft nose of 25% MAC of vertical tail divided by fuselage length--></position_ratio_on_fuselage>
+      </vertical_tail>
+    </geometry>
+    <aerodynamics>
+      <wing>
+        <CD>
+          <fuselage_interaction is_input="True">0.04</fuselage_interaction>
+        </CD>
+      </wing>
+    </aerodynamics>
+    <weight>
+      <aircraft>
+        <CG>
+          <range is_input="True">0.3<!--distance between front position and aft position of CG, as ratio of mean aerodynamic chord (allows to have front position of CG, as currently, FAST-OAD estimates only the aft position of CG)--></range>
+          <aft>
+            <MAC_position>
+              <margin is_input="True">0.05<!--Added margin for getting most aft CG position, as ratio of mean aerodynamic chord--></margin>
+            </MAC_position>
+          </aft>
+        </CG>
+        <payload>
+          <design_mass_per_passenger units="kg" is_input="True">90.72<!--Design value of mass per passenger--></design_mass_per_passenger>
+          <max_mass_per_passenger units="kg" is_input="True">130.72<!--Maximum value of mass per passenger--></max_mass_per_passenger>
+        </payload>
+      </aircraft>
+      <airframe>
+        <flight_controls>
+          <mass>
+            <k_fc is_input="True">0.000135<!--flight controls (A4): 0.85e-4 if electrical, 1.35e-4 if conventional--></k_fc>
+          </mass>
+        </flight_controls>
+        <fuselage>
+          <mass>
+            <k_fus is_input="True">1.0<!--correction coefficient: 1.00 if all engines under wing / 1.02 with 2 engines at rear / 1.03 if 3 engines at rear / 1.05 if 1 engine in vertical tail (with or without 2 engines under wing)--></k_fus>
+            <k_lg is_input="True">1.05<!--correction coefficient: 1.05 if main landing gear under wing / 1.10 if main landing gear under fuselage--></k_lg>
+          </mass>
+        </fuselage>
+        <landing_gear>
+          <front>
+            <weight_ratio is_input="True">0.08<!--part of aircraft weight that is supported by front landing gear--></weight_ratio>
+            <CG>
+              <position_ratio_on_front_fuselage is_input="True">0.75<!--x-distance between nose and front landing gear divided by data:geometry:fuselage:front_length--></position_ratio_on_front_fuselage>
+            </CG>
+          </front>
+        </landing_gear>
+        <wing>
+          <mass>
+            <k_mvo is_input="True">1.39<!--1.39 for Airbus type aircrafts--></k_mvo>
+          </mass>
+        </wing>
+      </airframe>
+      <systems>
+        <power>
+          <mass>
+            <k_elec is_input="True">1.0<!--electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)--></k_elec>
+          </mass>
+        </power>
+      </systems>
+    </weight>
+    <mission>
+      <sizing>
+        <breguet>
+          <climb>
+            <mass_ratio is_input="True">0.97<!--Input defined by the mission.--></mass_ratio>
+          </climb>
+          <descent>
+            <mass_ratio is_input="True">0.98<!--Input defined by the mission.--></mass_ratio>
+          </descent>
+          <reserve>
+            <mass_ratio is_input="True">0.06<!--Input defined by the mission.--></mass_ratio>
+          </reserve>
+        </breguet>
+      </sizing>
+    </mission>
+  </settings>
+  <tuning>
+    <propulsion>
+      <rubber_engine>
+        <SFC>
+          <k_cr is_input="True">1.0<!--correction ratio to apply to the computed SFC at cruise ceiling--></k_cr>
+          <k_sl is_input="True">1.0<!--correction ratio to apply to the computed SFC at sea level--></k_sl>
+        </SFC>
+      </rubber_engine>
+    </propulsion>
+    <aerodynamics>
+      <aircraft>
+        <cruise>
+          <CD>
+            <k is_input="True">1.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></k>
+            <offset is_input="True">0.0<!--correction offset to apply to computed drag coefficient in cruise conditions--></offset>
+            <compressibility>
+              <characteristic_mach_increment is_input="True">0.0<!--Increment to apply to the computed characteristic Mach (where compressibility drag is 20 d.c.)--></characteristic_mach_increment>
+              <max_value is_input="True">0.5<!--maximum authorized value for compressibility drag. Allows to prevent the model from overestimating the compressibility effect, especially for aircraft models after year 2000.--></max_value>
+            </compressibility>
+            <winglet_effect>
+              <k is_input="True">0.87<!--correction ratio to apply to computed induced drag coefficient in cruise conditions--></k>
+              <offset is_input="True">0.0<!--correction ratio to apply to computed drag coefficient in cruise conditions--></offset>
+            </winglet_effect>
+          </CD>
+          <CL>
+            <k is_input="True">1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
+            <offset is_input="True">0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
+            <winglet_effect>
+              <k is_input="True">1.0<!--ratio to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></k>
+              <offset is_input="True">0.0<!--offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation--></offset>
+            </winglet_effect>
+          </CL>
+        </cruise>
+        <landing>
+          <CL_max>
+            <landing_gear_effect>
+              <k is_input="True">1.0<!--correction ratio to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear--></k>
+            </landing_gear_effect>
+          </CL_max>
+        </landing>
+      </aircraft>
+      <high_lift_devices>
+        <landing>
+          <CD>
+            <multi_slotted_flap_effect>
+              <k is_input="True">1.0<!--correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps--></k>
+            </multi_slotted_flap_effect>
+          </CD>
+          <CL>
+            <multi_slotted_flap_effect>
+              <k is_input="True">1.0<!--correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps--></k>
+            </multi_slotted_flap_effect>
+          </CL>
+        </landing>
+      </high_lift_devices>
+    </aerodynamics>
+    <weight>
+      <airframe>
+        <flight_controls>
+          <mass>
+            <k is_input="True">1.0<!--flight controls (A4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--flight controls (A4): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </flight_controls>
+        <fuselage>
+          <mass>
+            <k is_input="True">1.1<!--fuselage (A2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--fuselage (A2): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </fuselage>
+        <horizontal_tail>
+          <mass>
+            <k is_input="True">1.08<!--horizontal tail (A31): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--horizontal tail (A31): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </horizontal_tail>
+        <landing_gear>
+          <mass>
+            <k is_input="True">0.85<!--landing gears (A5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--landing gears (A5): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </landing_gear>
+        <paint>
+          <mass>
+            <k is_input="True">1.0<!--paint (A7): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--paint (A7): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </paint>
+        <pylon>
+          <mass>
+            <k is_input="True">0.85<!--pylon (A6): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--pylon (A6): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </pylon>
+        <vertical_tail>
+          <mass>
+            <k is_input="True">1.0<!--vertical tail (A32): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--vertical tail (A32): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </vertical_tail>
+        <wing>
+          <mass>
+            <k is_input="True">1.05<!--wing (A1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--wing (A1): correction offset to be applied on computed mass--></offset>
+          </mass>
+          <bending_sizing>
+            <mass>
+              <k is_input="True">1.0<!--wing bending sizing (A11): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing bending sizing (A11): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </bending_sizing>
+          <reinforcements>
+            <mass>
+              <k is_input="True">1.0<!--wing reinforcements (A14): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing reinforcements (A14): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </reinforcements>
+          <ribs>
+            <mass>
+              <k is_input="True">1.0<!--wing ribs (A13): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing ribs (A13): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </ribs>
+          <secondary_parts>
+            <mass>
+              <k is_input="True">1.0<!--wing secondary parts (A15): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing secondary parts (A15): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </secondary_parts>
+          <shear_sizing>
+            <mass>
+              <k is_input="True">1.0<!--wing shear sizing (A12): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--wing shear sizing (A12): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </shear_sizing>
+        </wing>
+      </airframe>
+      <furniture>
+        <food_water>
+          <mass>
+            <k is_input="True">1.0<!--food water (D3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--food water (D3): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </food_water>
+        <passenger_seats>
+          <mass>
+            <k is_input="True">1.0<!--passenger seats (D2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--passenger seats (D2): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </passenger_seats>
+        <security_kit>
+          <mass>
+            <k is_input="True">1.0<!--security kit (D4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--security kit (D4): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </security_kit>
+        <toilets>
+          <mass>
+            <k is_input="True">1.0<!--toilets (D5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--toilets (D5): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </toilets>
+      </furniture>
+      <propulsion>
+        <engine>
+          <mass>
+            <k is_input="True">1.0<!--engine (B1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--engine (B1): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </engine>
+        <fuel_lines>
+          <mass>
+            <k is_input="True">1.0<!--fuel lines (B2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--fuel lines (B2): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </fuel_lines>
+        <unconsumables>
+          <mass>
+            <k is_input="True">1.0<!--unconsumables (B3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--unconsumables (B3): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </unconsumables>
+      </propulsion>
+      <systems>
+        <flight_kit>
+          <mass>
+            <k is_input="True">1.0<!--flight kit (C6): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--flight kit (C6): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </flight_kit>
+        <navigation>
+          <mass>
+            <k is_input="True">1.0<!--navigation (C3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--navigation (C3): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </navigation>
+        <operational>
+          <mass>
+            <k is_input="True">1.0<!--operational (C5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--operational (C5): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </operational>
+        <transmission>
+          <mass>
+            <k is_input="True">1.0<!--transmission (C4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg" is_input="True">0.0<!--transmission (C4): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </transmission>
+        <life_support>
+          <air_conditioning>
+            <mass>
+              <k is_input="True">1.0<!--air conditioning (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--air conditioning (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </air_conditioning>
+          <cabin_lighting>
+            <mass>
+              <k is_input="True">1.0<!--cabin lighting (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--cabin lighting (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </cabin_lighting>
+          <de-icing>
+            <mass>
+              <k is_input="True">1.0<!--de-icing (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--de-icing (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </de-icing>
+          <insulation>
+            <mass>
+              <k is_input="True">2.0<!--insulation (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--insulation (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </insulation>
+          <oxygen>
+            <mass>
+              <k is_input="True">1.0<!--oxygen (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--oxygen (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </oxygen>
+          <safety_equipment>
+            <mass>
+              <k is_input="True">1.0<!--safety equipment (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--safety equipment (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </safety_equipment>
+          <seats_crew_accommodation>
+            <mass>
+              <k is_input="True">1.0<!--seats crew accommodation (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--seats crew accommodation (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </seats_crew_accommodation>
+        </life_support>
+        <power>
+          <auxiliary_power_unit>
+            <mass>
+              <k is_input="True">1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </auxiliary_power_unit>
+          <electric_systems>
+            <mass>
+              <k is_input="True">1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass>
+              <k is_input="True">1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg" is_input="True">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </hydraulic_systems>
+        </power>
+      </systems>
+    </weight>
+  </tuning>
 </FASTOAD_model>

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -263,12 +263,12 @@ def test_api_eval_breguet(cleanup):
     _check_weight_performance_loop(problem)
 
     assert_allclose(problem["data:handling_qualities:static_margin"], 0.05, atol=1e-2)
-    assert_allclose(problem["data:geometry:wing:MAC:at25percent:x"], 17.149, atol=1e-2)
-    assert_allclose(problem["data:weight:aircraft:MTOW"], 74892, atol=1)
-    assert_allclose(problem["data:geometry:wing:area"], 126.732, atol=1e-2)
-    assert_allclose(problem["data:geometry:vertical_tail:area"], 27.565, atol=1e-2)
-    assert_allclose(problem["data:geometry:horizontal_tail:area"], 35.884, atol=1e-2)
-    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 19527, atol=1)
+    assert_allclose(problem["data:geometry:wing:MAC:at25percent:x"], 17.078, atol=1e-2)
+    assert_allclose(problem["data:weight:aircraft:MTOW"], 74862, atol=1)
+    assert_allclose(problem["data:geometry:wing:area"], 126.677, atol=1e-2)
+    assert_allclose(problem["data:geometry:vertical_tail:area"], 27.434, atol=1e-2)
+    assert_allclose(problem["data:geometry:horizontal_tail:area"], 35.626, atol=1e-2)
+    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 19516, atol=1)
 
 
 class MissionConfigurator(_IConfigurationModifier):
@@ -311,12 +311,12 @@ def test_api_eval_mission(cleanup):
     _check_weight_performance_loop(problem)
 
     assert_allclose(problem["data:handling_qualities:static_margin"], 0.05, atol=1e-2)
-    assert_allclose(problem["data:geometry:wing:MAC:at25percent:x"], 17.149, atol=1e-2)
-    assert_allclose(problem["data:weight:aircraft:MTOW"], 74696, atol=1)
-    assert_allclose(problem["data:geometry:wing:area"], 126.083, atol=1e-2)
-    assert_allclose(problem["data:geometry:vertical_tail:area"], 27.437, atol=1e-2)
-    assert_allclose(problem["data:geometry:horizontal_tail:area"], 35.731, atol=1e-2)
-    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 19390, atol=1)
+    assert_allclose(problem["data:geometry:wing:MAC:at25percent:x"], 17.077, atol=1e-2)
+    assert_allclose(problem["data:weight:aircraft:MTOW"], 74661, atol=1)
+    assert_allclose(problem["data:geometry:wing:area"], 126.011, atol=1e-2)
+    assert_allclose(problem["data:geometry:vertical_tail:area"], 27.305, atol=1e-2)
+    assert_allclose(problem["data:geometry:horizontal_tail:area"], 35.472, atol=1e-2)
+    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 19374, atol=1)
 
 
 def test_api_optim(cleanup):
@@ -347,13 +347,13 @@ def test_api_optim(cleanup):
     _check_weight_performance_loop(problem)
 
     # Design Variable
-    assert_allclose(problem["data:geometry:wing:aspect_ratio"], 14.52, atol=1e-2)
+    assert_allclose(problem["data:geometry:wing:aspect_ratio"], 14.58, atol=1e-2)
 
     # Constraint
-    assert_allclose(problem["data:geometry:wing:span"], 44.88, atol=2e-2)
+    assert_allclose(problem["data:geometry:wing:span"], 44.98, atol=2e-2)
 
     # Objective
-    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 18900.0, atol=1)
+    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 18884.6, atol=1)
 
 
 def _check_weight_performance_loop(problem):


### PR DESCRIPTION
This PR corrects two bugs in the tail geometries:
- `center:leading_edge:local:x` was incorrect due to a wrong formula for `MAC:at25percent:x:local` for HTP and VTP
- the VTP and HTP positions were incorrect for the T_tail configuration 