### PR TITLE
Tail areas scaling factors

### DIFF
--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
@@ -57,7 +57,7 @@ class ComputeHTArea(om.ExplicitComponent):
             "edge and VTP tip leading edge divided by VTP tip chord",
         )
 
-        self.add_input("settings:geometry:horizontal_tail:area_factor", val=1.0)
+        self.add_input("tuning:geometry:horizontal_tail:area_factor", val=1.0)
 
         self.add_output(
             "data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25", units="m", ref=30.0
@@ -96,7 +96,7 @@ class ComputeHTArea(om.ExplicitComponent):
         vt_le_x = inputs["data:geometry:vertical_tail:tip:leading_edge:x"]
         htp_le_position_ratio = inputs["settings:geometry:horizontal_tail:position_ratio_on_VTP"]
         htp_x0 = inputs["data:geometry:horizontal_tail:MAC:at25percent:x:local"]
-        htp_area_factor = inputs["settings:geometry:horizontal_tail:area_factor"]
+        htp_area_factor = inputs["tuning:geometry:horizontal_tail:area_factor"]
 
         delta_lg = x_main_lg - x_front_lg
         atm = Atmosphere(0.0)

--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_ht_area.py
@@ -57,6 +57,8 @@ class ComputeHTArea(om.ExplicitComponent):
             "edge and VTP tip leading edge divided by VTP tip chord",
         )
 
+        self.add_input("settings:geometry:horizontal_tail:area_factor", val=1.0)
+
         self.add_output(
             "data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25", units="m", ref=30.0
         )
@@ -94,6 +96,7 @@ class ComputeHTArea(om.ExplicitComponent):
         vt_le_x = inputs["data:geometry:vertical_tail:tip:leading_edge:x"]
         htp_le_position_ratio = inputs["settings:geometry:horizontal_tail:position_ratio_on_VTP"]
         htp_x0 = inputs["data:geometry:horizontal_tail:MAC:at25percent:x:local"]
+        htp_area_factor = inputs["settings:geometry:horizontal_tail:area_factor"]
 
         delta_lg = x_main_lg - x_front_lg
         atm = Atmosphere(0.0)
@@ -132,7 +135,7 @@ class ComputeHTArea(om.ExplicitComponent):
         else:
             raise ValueError("Value of data:geometry:has_T_tail can only be 0 or 1")
 
-        htp_area = ht_volume_coeff / aero_centers_distance * wing_area * wing_mac
+        htp_area = ht_volume_coeff / aero_centers_distance * wing_area * wing_mac * htp_area_factor
         wet_area_htp = wet_area_coeff * htp_area
 
         outputs["data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25"] = (

--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_vt_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_vt_area.py
@@ -37,6 +37,7 @@ class ComputeVTArea(om.ExplicitComponent):
         self.add_input(
             "data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25", val=np.nan, units="m"
         )
+        self.add_input("settings:geometry:vertical_tail:area_factor", val=1.0)
 
         self.add_output("data:geometry:vertical_tail:wetted_area", units="m**2", ref=100.0)
         self.add_output("data:geometry:vertical_tail:area", units="m**2", ref=50.0)
@@ -59,13 +60,18 @@ class ComputeVTArea(om.ExplicitComponent):
         cruise_mach = inputs["data:TLAR:cruise_mach"]
         # This one is the distance between the 25% MAC points
         wing_htp_distance = inputs["data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25"]
+        vtp_area_factor = inputs["settings:geometry:vertical_tail:area_factor"]
 
         # Matches suggested goal by Raymer, Fig 16.20
         cn_beta_goal = 0.0569 - 0.01694 * cruise_mach + 0.15904 * cruise_mach**2
 
         required_cnbeta_vtp = cn_beta_goal - cn_beta_fuselage
         distance_to_cg = wing_htp_distance + 0.25 * l0_wing - cg_mac_position * l0_wing
-        vt_area = required_cnbeta_vtp / (distance_to_cg / wing_area / span * cl_alpha_vt)
+        vt_area = (
+            required_cnbeta_vtp
+            / (distance_to_cg / wing_area / span * cl_alpha_vt)
+            * vtp_area_factor
+        )
         wet_vt_area = 2.1 * vt_area
 
         outputs["data:geometry:vertical_tail:wetted_area"] = wet_vt_area

--- a/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_vt_area.py
+++ b/src/fastoad_cs25/models/handling_qualities/tail_sizing/compute_vt_area.py
@@ -37,7 +37,7 @@ class ComputeVTArea(om.ExplicitComponent):
         self.add_input(
             "data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25", val=np.nan, units="m"
         )
-        self.add_input("settings:geometry:vertical_tail:area_factor", val=1.0)
+        self.add_input("tuning:geometry:vertical_tail:area_factor", val=1.0)
 
         self.add_output("data:geometry:vertical_tail:wetted_area", units="m**2", ref=100.0)
         self.add_output("data:geometry:vertical_tail:area", units="m**2", ref=50.0)
@@ -60,7 +60,7 @@ class ComputeVTArea(om.ExplicitComponent):
         cruise_mach = inputs["data:TLAR:cruise_mach"]
         # This one is the distance between the 25% MAC points
         wing_htp_distance = inputs["data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25"]
-        vtp_area_factor = inputs["settings:geometry:vertical_tail:area_factor"]
+        vtp_area_factor = inputs["tuning:geometry:vertical_tail:area_factor"]
 
         # Matches suggested goal by Raymer, Fig 16.20
         cn_beta_goal = 0.0569 - 0.01694 * cruise_mach + 0.15904 * cruise_mach**2

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -319,6 +319,7 @@ settings:weight:airframe:landing_gear:front:weight_ratio || part of aircraft wei
 settings:weight:airframe:wing:mass:k_mvo || 1.39 for Airbus type aircrafts
 settings:weight:systems:power:mass:k_elec || electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)
 settings:geometry:horizontal_tail:area_factor || scaling factor applied to horizontal tail area
+settings:geometry:vertical_tail:area_factor || scaling factor applied to vertical tail area
 settings:geometry:horizontal_tail:position_ratio_on_fuselage || (does not apply for T-tails) distance to aircraft nose of 25% MAC of horizontal tail divided by fuselage length
 settings:geometry:vertical_tail:position_ratio_on_fuselage || distance to aircraft nose of 25% MAC of vertical tail divided by fuselage length
 test:test_variable || for testing (do not remove, keep first)

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -318,8 +318,6 @@ settings:weight:airframe:fuselage:mass:k_lg || correction coefficient: 1.05 if m
 settings:weight:airframe:landing_gear:front:weight_ratio || part of aircraft weight that is supported by front landing gear
 settings:weight:airframe:wing:mass:k_mvo || 1.39 for Airbus type aircrafts
 settings:weight:systems:power:mass:k_elec || electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)
-settings:geometry:horizontal_tail:area_factor || scaling factor applied to horizontal tail area
-settings:geometry:vertical_tail:area_factor || scaling factor applied to vertical tail area
 settings:geometry:horizontal_tail:position_ratio_on_fuselage || (does not apply for T-tails) distance to aircraft nose of 25% MAC of horizontal tail divided by fuselage length
 settings:geometry:vertical_tail:position_ratio_on_fuselage || distance to aircraft nose of 25% MAC of vertical tail divided by fuselage length
 test:test_variable || for testing (do not remove, keep first)
@@ -337,6 +335,8 @@ tuning:aerodynamics:aircraft:landing:CL_max:landing_gear_effect:k || correction 
 tuning:aerodynamics:aircraft:landing:CL_max:landing_gear_effect:offset || correction offset to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear
 tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k || correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps
 tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k || correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps
+tuning:geometry:horizontal_tail:area_factor || scaling factor applied to horizontal tail area
+tuning:geometry:vertical_tail:area_factor || scaling factor applied to vertical tail area
 tuning:propulsion:rubber_engine:SFC:k_sl || correction ratio to apply to the computed SFC at sea level
 tuning:propulsion:rubber_engine:SFC:k_cr || correction ratio to apply to the computed SFC at cruise ceiling
 tuning:weight:airframe:flight_controls:mass:k || flight controls (A4): correction ratio to be applied on computed mass

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -318,6 +318,7 @@ settings:weight:airframe:fuselage:mass:k_lg || correction coefficient: 1.05 if m
 settings:weight:airframe:landing_gear:front:weight_ratio || part of aircraft weight that is supported by front landing gear
 settings:weight:airframe:wing:mass:k_mvo || 1.39 for Airbus type aircrafts
 settings:weight:systems:power:mass:k_elec || electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)
+settings:geometry:horizontal_tail:area_factor || scaling factor applied to horizontal tail area
 settings:geometry:horizontal_tail:position_ratio_on_fuselage || (does not apply for T-tails) distance to aircraft nose of 25% MAC of horizontal tail divided by fuselage length
 settings:geometry:vertical_tail:position_ratio_on_fuselage || distance to aircraft nose of 25% MAC of vertical tail divided by fuselage length
 test:test_variable || for testing (do not remove, keep first)


### PR DESCRIPTION
This PR adds scaling factors for HTP and VTP areas (`settings:geometry:horizontal_tail:area_factor` and `settings:geometry:horizontal_tail:area_factor`) which is particularly useful for tuning the model to yield reference aircraft.

Here are results (all MDAs converged) obtained for tests on a conventional tail with default inputs of FAST-OAD-CS25:

![newplot-8](https://github.com/user-attachments/assets/c00fa7c9-b7a2-4587-bf0c-89ff0f40e483)

![newplot-7](https://github.com/user-attachments/assets/9e12d13b-f1fe-482d-be55-680c94979662)

![newplot-9](https://github.com/user-attachments/assets/104ce156-f430-4331-8319-3b2a5063a528)
