### PR TITLE
Added possibility to specify absolute Y engine position

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ venv*/
 
 # External tools
 /XFOIL
+
+# Tests folders
+run_pytest*

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,3 @@ venv*/
 
 # External tools
 /XFOIL
-
-# Tests folders
-run_pytest*

--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -63,9 +63,15 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
     # TODO: Document equations. Cite sources
     """Nacelle and pylon geometry estimation"""
 
+    def initialize(self):
+        self.options.declare("impose_absolute_engine", types=bool, default=False)
+
     def setup(self):
         self.add_input("data:propulsion:MTO_thrust", val=np.nan, units="N")
-        self.add_input("data:geometry:propulsion:engine:y_ratio", val=np.nan)
+        if self.options["impose_absolute_engine"]:
+            self.add_input("data:geometry:propulsion:nacelle:y", val=np.nan, units="m")
+        else:
+            self.add_input("data:geometry:propulsion:engine:y_ratio", val=np.nan)
         self.add_input("data:geometry:propulsion:layout", val=np.nan)
         self.add_input("data:geometry:wing:span", val=np.nan, units="m")
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
@@ -87,7 +93,10 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         self.add_output("data:geometry:propulsion:nacelle:length", units="m")
         self.add_output("data:geometry:propulsion:nacelle:diameter", units="m")
         self.add_output("data:geometry:landing_gear:height", units="m")
-        self.add_output("data:geometry:propulsion:nacelle:y", units="m")
+        if self.options["impose_absolute_engine"]:
+            self.add_output("data:geometry:propulsion:engine:y_ratio")
+        else:
+            self.add_output("data:geometry:propulsion:nacelle:y", units="m")
         self.add_output("data:geometry:propulsion:pylon:wetted_area", units="m**2")
         self.add_output("data:geometry:propulsion:nacelle:wetted_area", units="m**2")
         self.add_output("data:weight:propulsion:engine:CG:x", units="m")
@@ -108,38 +117,39 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         self.declare_partials(
             "data:geometry:propulsion:pylon:length", "data:propulsion:MTO_thrust", method="fd"
         )
-        self.declare_partials(
-            "data:geometry:propulsion:nacelle:y",
-            [
-                "data:propulsion:MTO_thrust",
-                "data:geometry:fuselage:maximum_width",
-                "data:geometry:propulsion:engine:y_ratio",
-                "data:geometry:wing:span",
-            ],
-            method="fd",
-        )
-        self.declare_partials(
-            "data:weight:propulsion:engine:CG:x",
-            [
-                "data:geometry:wing:MAC:at25percent:x",
-                "data:geometry:wing:MAC:length",
-                "data:geometry:wing:MAC:leading_edge:x:local",
-                "data:geometry:wing:kink:leading_edge:x:local",
-                "data:geometry:wing:tip:leading_edge:x:local",
-                "data:geometry:wing:root:y",
-                "data:geometry:wing:kink:y",
-                "data:geometry:wing:tip:y",
-                "data:geometry:wing:root:chord",
-                "data:geometry:wing:kink:chord",
-                "data:geometry:wing:tip:chord",
-                "data:geometry:fuselage:length",
-                "data:propulsion:MTO_thrust",
-                "data:geometry:fuselage:maximum_width",
-                "data:geometry:propulsion:engine:y_ratio",
-                "data:geometry:wing:span",
-            ],
-            method="fd",
-        )
+        if not self.options["impose_absolute_engine"]:
+            self.declare_partials(
+                "data:geometry:propulsion:nacelle:y",
+                [
+                    "data:propulsion:MTO_thrust",
+                    "data:geometry:fuselage:maximum_width",
+                    "data:geometry:propulsion:engine:y_ratio",
+                    "data:geometry:wing:span",
+                ],
+                method="fd",
+            )
+            self.declare_partials(
+                "data:weight:propulsion:engine:CG:x",
+                [
+                    "data:geometry:wing:MAC:at25percent:x",
+                    "data:geometry:wing:MAC:length",
+                    "data:geometry:wing:MAC:leading_edge:x:local",
+                    "data:geometry:wing:kink:leading_edge:x:local",
+                    "data:geometry:wing:tip:leading_edge:x:local",
+                    "data:geometry:wing:root:y",
+                    "data:geometry:wing:kink:y",
+                    "data:geometry:wing:tip:y",
+                    "data:geometry:wing:root:chord",
+                    "data:geometry:wing:kink:chord",
+                    "data:geometry:wing:tip:chord",
+                    "data:geometry:fuselage:length",
+                    "data:propulsion:MTO_thrust",
+                    "data:geometry:fuselage:maximum_width",
+                    "data:geometry:propulsion:engine:y_ratio",
+                    "data:geometry:wing:span",
+                ],
+                method="fd",
+            )
         self.declare_partials(
             "data:geometry:propulsion:nacelle:wetted_area",
             "data:propulsion:MTO_thrust",
@@ -175,7 +185,9 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         outputs["data:geometry:propulsion:pylon:length"] = 1.1 * nacelle.length
         outputs["data:geometry:propulsion:fan:length"] = 0.60 * nacelle.length
 
-        y_nacelle = self._compute_nacelle_y(nacelle, inputs, propulsion_layout)
+        y_nacelle, y_nacelle_ratio = self._compute_nacelle_y(
+            nacelle, inputs, propulsion_layout, self.options["impose_absolute_engine"]
+        )
 
         if propulsion_layout == 1:
             if y_nacelle <= kink_chord.y:
@@ -192,7 +204,10 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         else:
             raise ValueError("Value of data:geometry:propulsion:layout can only be 1 or 2")
 
-        outputs["data:geometry:propulsion:nacelle:y"] = y_nacelle
+        if self.options["impose_absolute_engine"]:
+            outputs["data:geometry:propulsion:engine:y_ratio"] = y_nacelle_ratio
+        else:
+            outputs["data:geometry:propulsion:nacelle:y"] = y_nacelle
         outputs["data:weight:propulsion:engine:CG:x"] = x_nacelle_cg_absolute
 
         outputs["data:geometry:propulsion:pylon:wetted_area"] = 0.35 * nacelle.wetted_area
@@ -214,17 +229,30 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         return x_nacelle_cg
 
     @staticmethod
-    def _compute_nacelle_y(nacelle, inputs, propulsion_layout):
-        if propulsion_layout == 1:
-            y_nacelle = (
-                inputs["data:geometry:propulsion:engine:y_ratio"]
-                * inputs["data:geometry:wing:span"]
-                / 2.0
-            )
-        elif propulsion_layout == 2:
-            y_nacelle = (
-                inputs["data:geometry:fuselage:maximum_width"] / 2.0 + 0.5 * nacelle.diameter + 0.7
-            )
+    def _compute_nacelle_y(nacelle, inputs, propulsion_layout, is_y_abs):
+        if is_y_abs:
+            if propulsion_layout == 1:
+                y_ratio = inputs["data:geometry:propulsion:nacelle:y"] / (
+                    inputs["data:geometry:wing:span"] / 2
+                )
+            elif propulsion_layout == 2:
+                y_ratio = 0.0
+            else:
+                raise ValueError("Value of data:geometry:propulsion:layout can only be 1 or 2")
+            return inputs["data:geometry:propulsion:nacelle:y"], y_ratio
         else:
-            raise ValueError("Value of data:geometry:propulsion:layout can only be 1 or 2")
-        return y_nacelle
+            if propulsion_layout == 1:
+                y_nacelle = (
+                    inputs["data:geometry:propulsion:engine:y_ratio"]
+                    * inputs["data:geometry:wing:span"]
+                    / 2.0
+                )
+            elif propulsion_layout == 2:
+                y_nacelle = (
+                    inputs["data:geometry:fuselage:maximum_width"] / 2.0
+                    + 0.5 * nacelle.diameter
+                    + 0.7
+                )
+            else:
+                raise ValueError("Value of data:geometry:propulsion:layout can only be 1 or 2")
+            return y_nacelle, inputs["data:geometry:propulsion:engine:y_ratio"]

--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -117,7 +117,14 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         self.declare_partials(
             "data:geometry:propulsion:pylon:length", "data:propulsion:MTO_thrust", method="fd"
         )
-        if not self.options["impose_absolute_engine"]:
+        if self.options["impose_absolute_engine"]:
+            self.declare_partials(
+                "data:geometry:propulsion:engine:y_ratio",
+                ["data:geometry:wing:span", "data:geometry:propulsion:nacelle:y"],
+                method="fd",
+            )
+            inp_fd = "data:geometry:propulsion:nacelle:y"
+        else:
             self.declare_partials(
                 "data:geometry:propulsion:nacelle:y",
                 [
@@ -128,28 +135,30 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
                 ],
                 method="fd",
             )
-            self.declare_partials(
-                "data:weight:propulsion:engine:CG:x",
-                [
-                    "data:geometry:wing:MAC:at25percent:x",
-                    "data:geometry:wing:MAC:length",
-                    "data:geometry:wing:MAC:leading_edge:x:local",
-                    "data:geometry:wing:kink:leading_edge:x:local",
-                    "data:geometry:wing:tip:leading_edge:x:local",
-                    "data:geometry:wing:root:y",
-                    "data:geometry:wing:kink:y",
-                    "data:geometry:wing:tip:y",
-                    "data:geometry:wing:root:chord",
-                    "data:geometry:wing:kink:chord",
-                    "data:geometry:wing:tip:chord",
-                    "data:geometry:fuselage:length",
-                    "data:propulsion:MTO_thrust",
-                    "data:geometry:fuselage:maximum_width",
-                    "data:geometry:propulsion:engine:y_ratio",
-                    "data:geometry:wing:span",
-                ],
-                method="fd",
-            )
+            inp_fd = "data:geometry:propulsion:engine:y_ratio"
+
+        self.declare_partials(
+            "data:weight:propulsion:engine:CG:x",
+            [
+                "data:geometry:wing:MAC:at25percent:x",
+                "data:geometry:wing:MAC:length",
+                "data:geometry:wing:MAC:leading_edge:x:local",
+                "data:geometry:wing:kink:leading_edge:x:local",
+                "data:geometry:wing:tip:leading_edge:x:local",
+                "data:geometry:wing:root:y",
+                "data:geometry:wing:kink:y",
+                "data:geometry:wing:tip:y",
+                "data:geometry:wing:root:chord",
+                "data:geometry:wing:kink:chord",
+                "data:geometry:wing:tip:chord",
+                "data:geometry:fuselage:length",
+                "data:propulsion:MTO_thrust",
+                "data:geometry:fuselage:maximum_width",
+                "data:geometry:wing:span",
+                inp_fd,
+            ],
+            method="fd",
+        )
         self.declare_partials(
             "data:geometry:propulsion:nacelle:wetted_area",
             "data:propulsion:MTO_thrust",

--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/tests/test_geom_nacelle_pylon.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/tests/test_geom_nacelle_pylon.py
@@ -92,7 +92,6 @@ def test_geometry_nacelle_pylons_absolute_engine_y():
     input_vars.add_output("data:geometry:wing:tip:leading_edge:x:local", 0.0, units="m")
 
     component = ComputeNacelleAndPylonsGeometry(impose_absolute_engine=True)
-    # component.options["impose_absolute_engine"] = True
 
     problem = run_system(component, input_vars)
 

--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/tests/test_geom_nacelle_pylon.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/tests/test_geom_nacelle_pylon.py
@@ -67,7 +67,58 @@ def test_geometry_nacelle_pylons():
     cg_b1 = problem["data:weight:propulsion:engine:CG:x"]
     assert cg_b1 == pytest.approx(13.5, abs=1e-1)
 
-    # With no kink
+
+def test_geometry_nacelle_pylons_absolute_engine_y():
+    """Tests computation of the nacelle and pylons component"""
+
+    input_vars = om.IndepVarComp()
+    input_vars.add_output("data:geometry:fuselage:length", 37.507, units="m")
+    input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")
+    input_vars.add_output("data:geometry:propulsion:layout", 1.0, units=None)
+    input_vars.add_output("data:geometry:propulsion:nacelle:y", 5.373, units="m")
+    input_vars.add_output("data:geometry:wing:span", 31.603, units="m")
+    input_vars.add_output("data:geometry:wing:MAC:length", 4.457, units="m")
+    input_vars.add_output("data:geometry:wing:MAC:at25percent:x", 16.457, units="m")
+    input_vars.add_output("data:geometry:wing:MAC:leading_edge:x:local", 2.361, units="m")
+    input_vars.add_output("data:geometry:wing:kink:chord", 3.985, units="m")
+    input_vars.add_output("data:geometry:wing:kink:y", 6.321, units="m")
+    input_vars.add_output("data:geometry:wing:kink:leading_edge:x:local", 2.275, units="m")
+    input_vars.add_output("data:geometry:wing:root:chord", 6.26, units="m")
+    input_vars.add_output("data:geometry:wing:root:y", 1.96, units="m")
+    input_vars.add_output("data:propulsion:MTO_thrust", 117880.0, units="N")
+    # Tip chord should not be used in this case
+    input_vars.add_output("data:geometry:wing:tip:chord", 0.0, units="m")
+    input_vars.add_output("data:geometry:wing:tip:y", 0.0, units="m")
+    input_vars.add_output("data:geometry:wing:tip:leading_edge:x:local", 0.0, units="m")
+
+    component = ComputeNacelleAndPylonsGeometry(impose_absolute_engine=True)
+    # component.options["impose_absolute_engine"] = True
+
+    problem = run_system(component, input_vars)
+
+    pylon_length = problem["data:geometry:propulsion:pylon:length"]
+    assert pylon_length == pytest.approx(5.733, abs=1e-3)
+    fan_length = problem["data:geometry:propulsion:fan:length"]
+    assert fan_length == pytest.approx(3.127, abs=1e-3)
+    nacelle_length = problem["data:geometry:propulsion:nacelle:length"]
+    assert nacelle_length == pytest.approx(5.211, abs=1e-3)
+    nacelle_dia = problem["data:geometry:propulsion:nacelle:diameter"]
+    assert nacelle_dia == pytest.approx(2.172, abs=1e-3)
+    lg_height = problem["data:geometry:landing_gear:height"]
+    assert lg_height == pytest.approx(3.041, abs=1e-3)
+    y_nacelle_ratio = problem["data:geometry:propulsion:engine:y_ratio"]
+    assert y_nacelle_ratio == pytest.approx(0.34, abs=1e-3)
+    pylon_wet_area = problem["data:geometry:propulsion:pylon:wetted_area"]
+    assert pylon_wet_area == pytest.approx(7.563, abs=1e-3)
+    nacelle_wet_area = problem["data:geometry:propulsion:nacelle:wetted_area"]
+    assert nacelle_wet_area == pytest.approx(21.609, abs=1e-3)
+    cg_b1 = problem["data:weight:propulsion:engine:CG:x"]
+    assert cg_b1 == pytest.approx(13.5, abs=1e-1)
+
+
+def test_geometry_nacelle_pylons_no_kink():
+    """Tests computation of the nacelle and pylons component without kink"""
+
     input_vars = om.IndepVarComp()
     input_vars.add_output("data:geometry:fuselage:length", 37.507, units="m")
     input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")


### PR DESCRIPTION
This PR add the possibility to specify an absolute value in meters for the Y position of the engines. This is done by using a submodel option `impose_absolute_engine` that defaults to False to avoid breaking old code.