### PR TITLE
Added absolute positioning of kink and absolute trailing edge kink sweep angle

### DIFF
--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_relative_kink.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_relative_kink.py
@@ -1,0 +1,50 @@
+"""
+Estimation of relative kink from an absolute value
+"""
+
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import openmdao.api as om
+
+
+class ComputeRelativeKink(om.ExplicitComponent):
+    """Estimation of relative kink from an absolute value"""
+
+    def setup(self):
+        self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:tip:y", val=np.nan, units="m")
+
+        self.add_output("data:geometry:wing:kink:span_ratio")
+
+    def setup_partials(self):
+        self.declare_partials(
+            "data:geometry:wing:kink:span_ratio",
+            [
+                "data:geometry:wing:kink:y",
+                "data:geometry:wing:tip:y",
+            ],
+            method="fd",
+        )
+
+    def compute(self, inputs, outputs):
+        y3_wing = inputs["data:geometry:wing:kink:y"]
+        y4_wing = inputs["data:geometry:wing:tip:y"]
+
+        if y4_wing > 0:
+            wing_break = y3_wing / y4_wing
+        else:
+            wing_break = 0.0
+
+        outputs["data:geometry:wing:kink:span_ratio"] = wing_break

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
@@ -77,8 +77,8 @@ class ComputeInnerSweepWing(om.ExplicitComponent):
     def setup(self):
         self.add_input("data:geometry:wing:root:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:sweep_100_outer", val=np.nan, units="deg")
         self.add_input("data:geometry:wing:sweep_100_ratio", val=0.0, units=None)
-        self.add_input("data:geometry:wing:sweep_100_outer", val=0.0, units="deg")
 
         self.add_output("data:geometry:wing:sweep_100_inner", val=0.0, units="deg")
 

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_sweep_wing.py
@@ -31,10 +31,8 @@ class ComputeSweepWing(om.ExplicitComponent):
         self.add_input("data:geometry:wing:tip:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:root:virtual_chord", val=np.nan, units="m")
         self.add_input("data:geometry:wing:tip:chord", val=np.nan, units="m")
-        self.add_input("data:geometry:wing:sweep_100_ratio", val=0.0, units=None)
 
         self.add_output("data:geometry:wing:sweep_0", units="deg")
-        self.add_output("data:geometry:wing:sweep_100_inner", val=0.0, units="deg")
         self.add_output("data:geometry:wing:sweep_100_outer", units="deg")
 
     def setup_partials(self):
@@ -44,17 +42,6 @@ class ComputeSweepWing(om.ExplicitComponent):
                 "data:geometry:wing:tip:leading_edge:x:local",
                 "data:geometry:wing:root:y",
                 "data:geometry:wing:kink:y",
-            ],
-            method="fd",
-        )
-        self.declare_partials(
-            "data:geometry:wing:sweep_100_inner",
-            [
-                "data:geometry:wing:root:y",
-                "data:geometry:wing:root:virtual_chord",
-                "data:geometry:wing:tip:leading_edge:x:local",
-                "data:geometry:wing:tip:y",
-                "data:geometry:wing:tip:chord",
             ],
             method="fd",
         )
@@ -73,7 +60,6 @@ class ComputeSweepWing(om.ExplicitComponent):
     def compute(self, inputs, outputs):
         x4_wing = inputs["data:geometry:wing:tip:leading_edge:x:local"]
         y2_wing = inputs["data:geometry:wing:root:y"]
-        y3_wing = inputs["data:geometry:wing:kink:y"]
         y4_wing = inputs["data:geometry:wing:tip:y"]
         l1_wing = inputs["data:geometry:wing:root:virtual_chord"]
         l4_wing = inputs["data:geometry:wing:tip:chord"]
@@ -83,11 +69,36 @@ class ComputeSweepWing(om.ExplicitComponent):
         outputs["data:geometry:wing:sweep_0"] = (
             math.atan(x4_wing / (y4_wing - y2_wing)) / math.pi * 180.0
         )
+
+
+class ComputeInnerSweepWing(om.ExplicitComponent):
+    """Inner Wing sweep estimation"""
+
+    def setup(self):
+        self.add_input("data:geometry:wing:root:y", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:sweep_100_ratio", val=0.0, units=None)
+        self.add_input("data:geometry:wing:sweep_100_outer", val=0.0, units="deg")
+
+        self.add_output("data:geometry:wing:sweep_100_inner", val=0.0, units="deg")
+
+    def setup_partials(self):
+        self.declare_partials(
+            "data:geometry:wing:sweep_100_inner",
+            [
+                "data:geometry:wing:sweep_100_outer",
+                "data:geometry:wing:sweep_100_ratio",
+            ],
+            method="fd",
+        )
+
+    def compute(self, inputs, outputs):
+        y2_wing = inputs["data:geometry:wing:root:y"]
+        y3_wing = inputs["data:geometry:wing:kink:y"]
+        sweep_100_outer = inputs["data:geometry:wing:sweep_100_outer"]
         if y3_wing == y2_wing:
             ratio = 1.0
         else:
             ratio = inputs["data:geometry:wing:sweep_100_ratio"]
 
-        outputs["data:geometry:wing:sweep_100_inner"] = (
-            outputs["data:geometry:wing:sweep_100_outer"] * ratio
-        )
+        outputs["data:geometry:wing:sweep_100_inner"] = sweep_100_outer * ratio

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/compute_wing.py
@@ -17,6 +17,7 @@ Estimation of wing geometry
 import fastoad.api as oad
 import openmdao.api as om
 
+from ...constants import SERVICE_WING_GEOMETRY
 from .constants import (
     SERVICE_WING_GEOMETRY_GLOBAL_POSITIONS,
     SERVICE_WING_GEOMETRY_MFW,
@@ -24,7 +25,6 @@ from .constants import (
     SERVICE_WING_GEOMETRY_THICKNESS,
     SERVICE_WING_GEOMETRY_WET_AREA,
 )
-from ...constants import SERVICE_WING_GEOMETRY
 
 
 @oad.RegisterSubmodel(SERVICE_WING_GEOMETRY, "fastoad.submodel.geometry.wing.legacy")
@@ -33,11 +33,17 @@ class ComputeWingGeometry(om.Group):
 
     def initialize(self):
         self.options.declare("compute_thicknesses", types=bool, default=True)
+        self.options.declare("impose_sweep_100_inner", types=bool, default=False)
+        self.options.declare("impose_absolute_kink", types=bool, default=False)
 
     def setup(self):
+        planform_options = {
+            "impose_sweep_100_inner": self.options["impose_sweep_100_inner"],
+            "impose_absolute_kink": self.options["impose_absolute_kink"],
+        }
         self.add_subsystem(
             "planform",
-            oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_PLANFORM),
+            oad.RegisterSubmodel.get_submodel(SERVICE_WING_GEOMETRY_PLANFORM, planform_options),
             promotes=["*"],
         )
         self.add_subsystem(

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/tests/test_compute_wing.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/tests/test_compute_wing.py
@@ -58,6 +58,45 @@ def test_compute_wing_with_kink():
     assert problem["data:weight:aircraft:MFW"] == pytest.approx(19322.5, abs=1e-1)
 
 
+def test_compute_wing_with_absolute_kink():
+    input_vars = om.IndepVarComp()
+    input_vars.add_output("data:TLAR:cruise_mach", 0.78, units=None)
+    input_vars.add_output("data:geometry:fuselage:maximum_height", 4.06, units="m")
+    input_vars.add_output("data:geometry:fuselage:maximum_width", 3.92, units="m")
+    input_vars.add_output("data:geometry:wing:area", 124.843, units="m**2")
+    input_vars.add_output("data:geometry:wing:aspect_ratio", 9.48, units=None)
+    input_vars.add_output("data:geometry:wing:sweep_25", 25.0, units="deg")
+    input_vars.add_output("data:geometry:wing:virtual_taper_ratio", 0.38, units=None)
+    input_vars.add_output("data:geometry:wing:kink:y", 6.88, units="m")
+
+    problem = run_system(ComputeWingGeometry(impose_absolute_kink=True), input_vars)
+
+    assert problem["data:geometry:wing:MAC:leading_edge:x:local"] == pytest.approx(2.524, abs=1e-3)
+    assert problem["data:geometry:wing:MAC:length"] == pytest.approx(4.182, abs=1e-3)
+    assert problem["data:geometry:wing:MAC:y"] == pytest.approx(6.710, abs=1e-3)
+    assert problem["data:geometry:wing:b_50"] == pytest.approx(37.33, abs=1e-3)
+    assert problem["data:geometry:wing:kink:chord"] == pytest.approx(3.540, abs=1e-3)
+    assert problem["data:geometry:wing:kink:leading_edge:x:local"] == pytest.approx(2.516, abs=1e-3)
+    assert problem["data:geometry:wing:kink:thickness_ratio"] == pytest.approx(0.121, abs=1e-3)
+    assert problem["data:geometry:wing:outer_area"] == pytest.approx(101.105, abs=1e-3)
+    assert problem["data:geometry:wing:root:chord"] == pytest.approx(6.056, abs=1e-2)
+    assert problem["data:geometry:wing:root:thickness_ratio"] == pytest.approx(0.159, abs=1e-3)
+    assert problem["data:geometry:wing:root:virtual_chord"] == pytest.approx(4.426, abs=1e-3)
+    assert problem["data:geometry:wing:root:y"] == pytest.approx(1.96, abs=1e-2)
+    assert problem["data:geometry:wing:span"] == pytest.approx(34.4, abs=1e-1)
+    assert problem["data:geometry:wing:sweep_0"] == pytest.approx(27.08, abs=1e-2)
+    assert problem["data:geometry:wing:sweep_100_inner"] == pytest.approx(0.0, abs=1e-1)
+    assert problem["data:geometry:wing:sweep_100_outer"] == pytest.approx(18.33, abs=1e-1)
+    assert problem["data:geometry:wing:taper_ratio"] == pytest.approx(0.2777, abs=1e-3)
+    assert problem["data:geometry:wing:thickness_ratio"] == pytest.approx(0.128, abs=1e-3)
+    assert problem["data:geometry:wing:tip:chord"] == pytest.approx(1.682, abs=1e-3)
+    assert problem["data:geometry:wing:tip:leading_edge:x:local"] == pytest.approx(7.793, abs=1e-3)
+    assert problem["data:geometry:wing:tip:thickness_ratio"] == pytest.approx(0.110, abs=1e-2)
+    assert problem["data:geometry:wing:tip:y"] == pytest.approx(17.2, abs=1e-1)
+    assert problem["data:geometry:wing:wetted_area"] == pytest.approx(202.209, abs=1e-3)
+    assert problem["data:weight:aircraft:MFW"] == pytest.approx(19322.5, abs=1e-1)
+
+
 def test_compute_wing_without_kink():
     # Method 1 : kink span_ratio = 0.
     input_vars = om.IndepVarComp()


### PR DESCRIPTION
This PR add the possibility to specify an absolute value in meters for the Y position of the kink and also an absolute value for the kink sweep angle @ trailing edge. This is done by using two submodel options: `impose_absolute_kink` and `impose_sweep_100_inner`.