### PR TITLE
Update building and publishing workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -62,12 +62,12 @@ jobs:
         run: poetry build
         shell: bash
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheel
           path: dist/*.whl
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: source
           path: dist/*.gz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "FAST-OAD-CS25"
-version = "0.7.3"
+version = "0.7.5"
 description = "FAST-OAD_CS25 is a FAST-OAD plugin with CS25/FAR25-related models."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Needed because v3 has been deprecated and caused a fail in the building process. More info here: [actions/upload-artifact: v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)