### PR TITLE
Adding center virtual chord evaluation

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,36 +1,36 @@
-@book{roux:2002,
-    author = {Elodie Roux},
-    title = {	Modèles Moteurs... Réacteurs double flux civils et réacteurs militaires à faible taux de dilution avec Post-Combustion},
-    publisher = {INSA-SupAéro-ONÉRA},
-    year = {2002},
-    url = {http://elodieroux.com/ReportFiles/ModelesMoteurVersionPublique.pdf},
-}
-
-@phdthesis{roux:2005,
-    author = {Elodie Roux},
-    title = {Pour une approche analytique de la Dynamique du Vol},
-    school = {SupAéro},
-    year = {2005},
-    url = {http://depozit.isae.fr/theses/2005/2005_Roux_Elodie.pdf},
+@misc{kroo:2001,
+  url  = {https://web.archive.org/web/20010307121417/http://adg.stanford.edu/aa241/propulsion/nacelledesign.html},
+  year = {2001},
 }
 
 @book{raymer:1999,
-    author = {Raymer, Daniel P.},
-    title = {Aircraft Design: A Conceptual Approach, Third edition},
-    year = {1999},
-    isbn = {1563473437},
-    publisher = {AIAA (American Institute of Aeronautics \& Astronautics},
+  author    = {Raymer, Daniel P.},
+  isbn      = {1563473437},
+  publisher = {AIAA (American Institute of Aeronautics \& Astronautics)},
+  title     = {Aircraft Design: A Conceptual Approach, Third edition},
+  year      = {1999},
 }
 
-@misc{kroo:2001,
-    url={https://web.archive.org/web/20010307121417/http://adg.stanford.edu/aa241/propulsion/nacelledesign.html},
-    year = {2001}
+@book{roux:2002,
+  author    = {Elodie Roux},
+  publisher = {INSA-SupAéro-ONÉRA},
+  title     = {	Modèles Moteurs... Réacteurs double flux civils et réacteurs militaires à faible taux de dilution avec Post-Combustion},
+  url       = {http://elodieroux.com/ReportFiles/ModelesMoteurVersionPublique.pdf},
+  year      = {2002},
+}
+
+@phdthesis{roux:2005,
+  author = {Elodie Roux},
+  school = {SupAéro},
+  title  = {Pour une approche analytique de la Dynamique du Vol},
+  url    = {http://depozit.isae.fr/theses/2005/2005_Roux_Elodie.pdf},
+  year   = {2005},
 }
 
 @book{supaero:2014,
-    author = {Dupont, Willy Pierre and Colongo, Christian and Atinault, Olivier and Cros, Christophe},
-    publisher = {ISAE-SUPAERO},
-    title = {Preliminary Design of a Commercial Transport Aircraft},
-    year = {2014}
+  author    = {Dupont, Willy Pierre and Colongo, Christian and Atinault, Olivier and Cros, Christophe},
+  publisher = {ISAE-SUPAERO},
+  title     = {Preliminary Design of a Commercial Transport Aircraft},
+  year      = {2014},
 }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -568,13 +568,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fast-oad-core"
-version = "1.8.1"
+version = "1.8.3"
 description = "FAST-OAD is a framework for performing rapid Overall Aircraft Design"
 optional = false
 python-versions = "<3.13,>=3.9"
 files = [
-    {file = "fast_oad_core-1.8.1-py3-none-any.whl", hash = "sha256:99757f13549b23310a38f1cedafc8742b14a6262d4f64c03f6bd22e3612cb85e"},
-    {file = "fast_oad_core-1.8.1.tar.gz", hash = "sha256:d935c9560df2a41b13efa7f824df8e3b0550ffedea1911d411cec5512c4d950c"},
+    {file = "fast_oad_core-1.8.3-py3-none-any.whl", hash = "sha256:dade9f4a562b0ed740db9522ead10de30baee406292f22f803602698769b5064"},
+    {file = "fast_oad_core-1.8.3.tar.gz", hash = "sha256:c2a84571ba65a2e0cebb5c8d02a0c641b641cd6020cc845bd0501f209ba0b610"},
 ]
 
 [package.dependencies]
@@ -602,7 +602,7 @@ lxml = [
     {version = ">=4.9.3,<6", markers = "python_version >= \"3.11\" and python_version < \"4.0\""},
 ]
 numpy = ">=1.23.2,<3"
-openmdao = ">=3.27,<4.0"
+openmdao = ">3.27,<3.38"
 pandas = [
     {version = ">=1.3.4,<3", markers = "python_version < \"3.11\""},
     {version = ">=1.5.3,<3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
@@ -621,8 +621,8 @@ tomlkit = ">=0.5.3,<1"
 wop = ">=2.2.0,<3.0.0"
 
 [package.extras]
-mpi = ["mpi4py (>=3.1.3,<4.0.0)", "mpi4py (>=3.1.4,<4.0.0)", "mpi4py (>=3.1.5,<4.0.0)"]
-mpi4py = ["mpi4py (>=3.1.3,<4.0.0)", "mpi4py (>=3.1.4,<4.0.0)", "mpi4py (>=3.1.5,<4.0.0)"]
+mpi = ["mpi4py (>=4.0.2,<5.0.0)"]
+mpi4py = ["mpi4py (>=4.0.2,<5.0.0)"]
 
 [[package]]
 name = "fastjsonschema"
@@ -3538,4 +3538,4 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "03a91a1bb4f477beccb12b8c83f74260619d0e6da3d2ea3d7f771597ffdfa67e"
+content-hash = "fba1f8a9eeaf538138934e7e32bcf4d1b8a11805c58303c87da74c0a5b01c1b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "FAST-OAD-CS25"
-version = "0.7.3"
+version = "0.7.5"
 description = "FAST-OAD_CS25 is a FAST-OAD plugin with CS25/FAR25-related models."
 readme = "README.md"
 authors = [
@@ -44,7 +44,7 @@ classifiers = [
 # the commit fail because "files were modified by this hook". In that case,
 # doing again the commit including changes in docs/requirements.txt will succeed.
 python = "^3.9"
-fast-oad-core = { version = "^1.7.3", python = "<3.13" }
+fast-oad-core = { version = "^1.8.3", python = "<3.13" }
 pyparsing = "^3.0.0"  # needed, but not declared as required, by OpenMDAO for file_wrap utility.
 
 [tool.poetry.group.test.dependencies]

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_center_chord.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_center_chord.py
@@ -85,9 +85,7 @@ class ComputeCenterChord(om.ExplicitComponent):
 
         # Linear interpolation to evaluate the central chord
         line_x_leading_edge = make_interp_spline(y_values, x_values, k=1)
-        x_leading_edge = line_x_leading_edge(0.0)
         line_l_center = make_interp_spline(y_values, l_values, k=1)
-        l_center = line_l_center(0.0)
 
-        outputs["data:geometry:wing:center:chord"] = l_center
-        outputs["data:geometry:wing:center:leading_edge:x:local"] = x_leading_edge
+        outputs["data:geometry:wing:center:chord"] = line_l_center(0.0)
+        outputs["data:geometry:wing:center:leading_edge:x:local"] = line_x_leading_edge(0.0)

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_center_chord.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_center_chord.py
@@ -1,0 +1,93 @@
+"""
+Estimation of center wing chord (l1')
+"""
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import openmdao.api as om
+from scipy.interpolate import interp1d
+
+
+class ComputeCenterChord(om.ExplicitComponent):
+    # TODO: Document equations. Cite sources
+    """Estimation of center wing chord (l1')"""
+
+    def setup(self):
+        self.add_input("data:geometry:wing:root:chord", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:root:y", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:kink:chord", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:kink:leading_edge:x:local", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:tip:chord", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:tip:leading_edge:x:local", val=np.nan, units="m")
+        self.add_input("data:geometry:wing:tip:y", val=np.nan, units="m")
+
+        self.add_output("data:geometry:wing:center:chord", units="m")
+        self.add_output("data:geometry:wing:center:leading_edge:x:local", units="m")
+
+    def setup_partials(self):
+        self.declare_partials(
+            "data:geometry:wing:center:chord",
+            [
+                "data:geometry:wing:root:chord",
+                "data:geometry:wing:root:y",
+                "data:geometry:wing:kink:chord",
+                "data:geometry:wing:kink:leading_edge:x:local",
+                "data:geometry:wing:kink:y",
+                "data:geometry:wing:tip:chord",
+                "data:geometry:wing:tip:leading_edge:x:local",
+                "data:geometry:wing:tip:y",
+            ],
+            method="fd",
+        )
+        self.declare_partials(
+            "data:geometry:wing:center:leading_edge:x:local",
+            [
+                "data:geometry:wing:root:chord",
+                "data:geometry:wing:root:y",
+                "data:geometry:wing:kink:chord",
+                "data:geometry:wing:kink:leading_edge:x:local",
+                "data:geometry:wing:kink:y",
+                "data:geometry:wing:tip:chord",
+                "data:geometry:wing:tip:leading_edge:x:local",
+                "data:geometry:wing:tip:y",
+            ],
+            method="fd",
+        )
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        l2_wing = inputs["data:geometry:wing:root:chord"]
+        y2_wing = inputs["data:geometry:wing:root:y"]
+        l3_wing = inputs["data:geometry:wing:kink:chord"]
+        x3_wing = inputs["data:geometry:wing:kink:leading_edge:x:local"]
+        y3_wing = inputs["data:geometry:wing:kink:y"]
+        l4_wing = inputs["data:geometry:wing:tip:chord"]
+        x4_wing = inputs["data:geometry:wing:tip:leading_edge:x:local"]
+        y4_wing = inputs["data:geometry:wing:tip:y"]
+
+        if y3_wing <= y2_wing:
+            y_values = np.squeeze([y2_wing, y4_wing])
+            x_values = np.squeeze([[0.0], x4_wing])
+            l_values = np.squeeze([l2_wing, l4_wing])
+        else:
+            y_values = np.squeeze([y2_wing, y3_wing, y4_wing])
+            x_values = np.squeeze([[0.0], x3_wing, x4_wing])
+            l_values = np.squeeze([l2_wing, l3_wing, l4_wing])
+        x_interp = interp1d(y_values, x_values, fill_value="extrapolate")
+        x_leading_edge = x_interp(0.0)
+        l_interp = interp1d(y_values, l_values, fill_value="extrapolate")
+        l_center = l_interp(0.0)
+
+        outputs["data:geometry:wing:center:chord"] = l_center
+        outputs["data:geometry:wing:center:leading_edge:x:local"] = x_leading_edge

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_planform.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_planform.py
@@ -18,6 +18,7 @@ import fastoad.api as oad
 
 from ..constants import SERVICE_WING_GEOMETRY_PLANFORM
 from .compute_b_50 import ComputeB50
+from .compute_center_chord import ComputeCenterChord
 from .compute_l1_l4 import ComputeL1AndL4Wing
 from .compute_l2_l3 import ComputeL2AndL3Wing
 from .compute_mac_wing import ComputeMACWing
@@ -55,6 +56,7 @@ class ComputeWingGeometry(
         self.add_subsystem("mac_wing", ComputeMACWing(), promotes=["*"])
         self.add_subsystem("b50_wing", ComputeB50(), promotes=["*"])
         self.add_subsystem("sweep_wing", ComputeSweepWing(), promotes=["*"])
+        self.add_subsystem("compute_center_chord", ComputeCenterChord(), promotes=["*"])
         if not self.options["impose_sweep_100_inner"]:
             self.add_subsystem("eval_sweep_inner", ComputeInnerSweepWing(), promotes=["*"])
         if self.options["impose_absolute_kink"]:

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -20,6 +20,7 @@ import pytest
 from fastoad.testing import run_system
 
 from ..compute_b_50 import ComputeB50
+from ..compute_center_chord import ComputeCenterChord
 from ..compute_l1_l4 import ComputeL1AndL4Wing
 from ..compute_l2_l3 import ComputeL2AndL3Wing
 from ..compute_mac_wing import ComputeMACWing
@@ -211,6 +212,26 @@ def test_geometry_wing_sweep_inner():
 
     sweep_100_inner = problem["data:geometry:wing:sweep_100_inner"]
     assert sweep_100_inner == pytest.approx(16.7, abs=1e-1)
+
+
+def test_geometry_compute_center_chord():
+    """Tests computation of the wing center chord and X position"""
+    input_vars = om.IndepVarComp()
+    input_vars.add_output("data:geometry:wing:area", 124.843, units="m**2")
+    input_vars.add_output("data:geometry:wing:kink:chord", 3.985, units="m")
+    input_vars.add_output("data:geometry:wing:kink:y", 6.321, units="m")
+    input_vars.add_output("data:geometry:wing:kink:leading_edge:x:local", 2.275, units="m")
+    input_vars.add_output("data:geometry:wing:root:chord", 6.26, units="m")
+    input_vars.add_output("data:geometry:wing:root:y", 1.96, units="m")
+    input_vars.add_output("data:geometry:wing:tip:chord", 1.882, units="m")
+    input_vars.add_output("data:geometry:wing:tip:y", 15.801, units="m")
+    input_vars.add_output("data:geometry:wing:tip:leading_edge:x:local", 7.222, units="m")
+
+    problem = run_system(ComputeCenterChord(), input_vars)
+    l_center = problem["data:geometry:wing:center:chord"]
+    assert l_center == pytest.approx(7.282, abs=1e-3)
+    x_leading_edge_center = problem["data:geometry:wing:center:leading_edge:x:local"]
+    assert x_leading_edge_center == pytest.approx(-1.022, abs=1e-3)
 
 
 def test_geometry_wing_sweep_complete():

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -228,9 +228,11 @@ def test_geometry_compute_center_chord():
     input_vars.add_output("data:geometry:wing:tip:leading_edge:x:local", 7.222, units="m")
 
     problem = run_system(ComputeCenterChord(), input_vars)
-    l_center = problem["data:geometry:wing:center:chord"]
+    l_center = problem.get_val("data:geometry:wing:center:chord", units="m")
     assert l_center == pytest.approx(7.282, abs=1e-3)
-    x_leading_edge_center = problem["data:geometry:wing:center:leading_edge:x:local"]
+    x_leading_edge_center = problem.get_val(
+        "data:geometry:wing:center:leading_edge:x:local", units="m"
+    )
     assert x_leading_edge_center == pytest.approx(-1.022, abs=1e-3)
 
 

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -156,6 +156,8 @@ data:geometry:wing:MAC:y || Y-position of mean aerodynamic chord of wing
 data:geometry:wing:area || wing reference area
 data:geometry:wing:aspect_ratio || wing aspect ratio
 data:geometry:wing:b_50 || actual length between root and tip along 50% of chord
+data:geometry:wing:center:chord || chord length at wing Y axis of symmetry
+data:geometry:wing:center:leading_edge:x:local || X-position of leading edge at wing center w.r.t. leading edge of root chord
 data:geometry:wing:kink:chord || chord length at wing kink
 data:geometry:wing:kink:leading_edge:x:local || X-position of leading edge at wing kink w.r.t. leading edge of root chord
 data:geometry:wing:kink:span_ratio || ratio (Y-position of kink)/(semi-span)

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -156,7 +156,7 @@ data:geometry:wing:MAC:y || Y-position of mean aerodynamic chord of wing
 data:geometry:wing:area || wing reference area
 data:geometry:wing:aspect_ratio || wing aspect ratio
 data:geometry:wing:b_50 || actual length between root and tip along 50% of chord
-data:geometry:wing:center:chord || chord length at wing Y axis of symmetry
+data:geometry:wing:center:chord || chord length at wing Y axis of symmetry (fuselage center line)
 data:geometry:wing:center:leading_edge:x:local || X-position of leading edge at wing center w.r.t. leading edge of root chord
 data:geometry:wing:kink:chord || chord length at wing kink
 data:geometry:wing:kink:leading_edge:x:local || X-position of leading edge at wing kink w.r.t. leading edge of root chord

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -347,13 +347,13 @@ def test_api_optim(cleanup):
     _check_weight_performance_loop(problem)
 
     # Design Variable
-    assert_allclose(problem["data:geometry:wing:aspect_ratio"], 14.58, atol=1e-2)
+    assert_allclose(problem["data:geometry:wing:aspect_ratio"], 14.56, atol=3e-2, rtol=1e-4)
 
     # Constraint
-    assert_allclose(problem["data:geometry:wing:span"], 44.98, atol=2e-2)
+    assert_allclose(problem["data:geometry:wing:span"], 44.9, atol=1e-1, rtol=1e-4)
 
     # Objective
-    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 18884.6, atol=1)
+    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 18885.0, atol=1, rtol=1e-4)
 
 
 def _check_weight_performance_loop(problem):


### PR DESCRIPTION
This PR add a simple OpenMDAO that permit to evaluate L1', the chord and X position of the virtual chord obtained by projecting L1 to the X symmetry axis. Additionally, we also updated the test values for the `test_api_optim` integration test with the latest values of Fast OAD Core. Finally, to temporarily solve a [fast OAD issue](https://github.com/fast-aircraft-design/FAST-OAD/issues/612), we needed to update the dependency of core to 1.8.3

![image](https://github.com/user-attachments/assets/1b958d97-6cc1-4149-ab05-4fce7f98aea2)
