### PR TITLE
Created new loads discipline and updated tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,9 +100,9 @@ addopts = "--cov-report term-missing --cov-report html --verbose"
 testpaths = ["src", "tests"]
 norecursedirs = ["dist", "build", ".tox"]
 filterwarnings = ["default"]
-markers = [
-    "skip_if_no_xfoil",
-]
+
+# Use @pytest.mark.skip_if_no_xfoil() before a test to skip it if xfoil_path fixture returns None and OS is not Windows.
+markers = ["skip_if_no_xfoil: skip test if XFOIL is not installed or not found in the system PATH"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ addopts = "--cov-report term-missing --cov-report html --verbose"
 testpaths = ["src", "tests"]
 norecursedirs = ["dist", "build", ".tox"]
 filterwarnings = ["default"]
+markers = [
+    "skip_if_no_xfoil",
+]
 
 [tool.coverage.run]
 branch = true

--- a/src/fastoad_cs25/configurations/cs25_base.yaml
+++ b/src/fastoad_cs25/configurations/cs25_base.yaml
@@ -38,6 +38,8 @@ model:
       id: fastoad.geometry.legacy
     weight:
       id: fastoad.weight.legacy
+    loads:
+      id: fastoad.loads.legacy
     mtow:
       id: fastoad.mass_performances.compute_MTOW
     hq_tail_sizing:

--- a/src/fastoad_cs25/models/loads/__init__.py
+++ b/src/fastoad_cs25/models/loads/__init__.py
@@ -1,3 +1,4 @@
+"""Python package for evaluating external and internal loads."""
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify

--- a/src/fastoad_cs25/models/loads/__init__.py
+++ b/src/fastoad_cs25/models/loads/__init__.py
@@ -1,4 +1,4 @@
-"""Python package for evaluating external and internal loads."""
+"""Python package for evaluating aerostructural loads."""
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify

--- a/src/fastoad_cs25/models/loads/__init__.py
+++ b/src/fastoad_cs25/models/loads/__init__.py
@@ -1,8 +1,5 @@
-"""
-Test package
-"""
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -13,8 +10,3 @@ Test package
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from pathlib import Path
-
-root_folder_path = Path(__file__).parent.parent
-""" Path of the whole project folder """

--- a/src/fastoad_cs25/models/loads/constants.py
+++ b/src/fastoad_cs25/models/loads/constants.py
@@ -1,8 +1,6 @@
-"""
-Test package
-"""
+"""Constants for loads submodels."""
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,7 +12,6 @@ Test package
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from pathlib import Path
-
-root_folder_path = Path(__file__).parent.parent
-""" Path of the whole project folder """
+SERVICE_SIZING_LOADS_ENVELOPE = "service.loads.sizing_loads_envelope"
+SERVICE_GUST_LOADS = "service.loads.gust_loads"
+SERVICE_MANEUVER_LOADS = "service.loads.maneuver_loads"

--- a/src/fastoad_cs25/models/loads/constants.py
+++ b/src/fastoad_cs25/models/loads/constants.py
@@ -1,4 +1,4 @@
-"""Constants for loads submodels."""
+"""Python module for constants of loads submodels and services."""
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify

--- a/src/fastoad_cs25/models/loads/constants.py
+++ b/src/fastoad_cs25/models/loads/constants.py
@@ -13,5 +13,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 SERVICE_SIZING_LOADS_ENVELOPE = "service.loads.sizing_loads_envelope"
+SERVICE_SIZING_LOADS_MAX = "service.loads.sizing_loads_max"
 SERVICE_GUST_LOADS = "service.loads.gust_loads"
 SERVICE_MANEUVER_LOADS = "service.loads.maneuver_loads"

--- a/src/fastoad_cs25/models/loads/loads.py
+++ b/src/fastoad_cs25/models/loads/loads.py
@@ -31,7 +31,8 @@ class ComputeLoads(om.Group):
             types=bool,
             default=True,
             desc="If False this simulates a dry wing,"
-            "i.e. the sizing load 2 does not take into account the fuel weight.",
+            "i.e. the sizing load 2 (pull-up/vertical gust at MTOW) does not take into account "
+            "the fuel weight.",
         )
 
     def setup(self):

--- a/src/fastoad_cs25/models/loads/loads.py
+++ b/src/fastoad_cs25/models/loads/loads.py
@@ -1,0 +1,55 @@
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+
+# from fastoad.module_management.constants import ModelDomain
+from fastoad.module_management.service_registry import RegisterOpenMDAOSystem, RegisterSubmodel
+
+from .constants import (
+    SERVICE_GUST_LOADS,
+    SERVICE_MANEUVER_LOADS,
+    SERVICE_SIZING_LOADS_ENVELOPE,
+)
+
+
+@RegisterOpenMDAOSystem("fastoad.loads.legacy")  # TODO add ModelDomain.LOADS
+class ComputeLoads(om.Group):
+    def initialize(self):
+        self.options.declare(
+            "fuel_load_alleviation",
+            types=bool,
+            default=True,
+            desc="If False this simulates a dry wing,"
+            "i.e. the sizing load 2 does not take into account the fuel weight.",
+        )
+
+    def setup(self):
+        fuel_load_alleviation_option = {
+            "fuel_load_alleviation": self.options["fuel_load_alleviation"]
+        }
+        self.add_subsystem(
+            "gust_loads",
+            RegisterSubmodel.get_submodel(SERVICE_GUST_LOADS, fuel_load_alleviation_option),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "maneuver_loads",
+            RegisterSubmodel.get_submodel(SERVICE_MANEUVER_LOADS, fuel_load_alleviation_option),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "sizing_loads_envelope",
+            RegisterSubmodel.get_submodel(SERVICE_SIZING_LOADS_ENVELOPE),
+            promotes=["*"],
+        )

--- a/src/fastoad_cs25/models/loads/loads.py
+++ b/src/fastoad_cs25/models/loads/loads.py
@@ -1,3 +1,4 @@
+"""Python package for evaluating aerostructural loads."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -11,11 +12,10 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import fastoad.api as oad
 import openmdao.api as om
 
 # from fastoad.module_management.constants import ModelDomain
-from fastoad.module_management.service_registry import RegisterOpenMDAOSystem, RegisterSubmodel
-
 from .constants import (
     SERVICE_GUST_LOADS,
     SERVICE_MANEUVER_LOADS,
@@ -24,7 +24,7 @@ from .constants import (
 )
 
 
-@RegisterOpenMDAOSystem("fastoad.loads.legacy")  # TODO add ModelDomain.LOADS
+@oad.RegisterOpenMDAOSystem("fastoad.loads.legacy")  # TODO add ModelDomain.LOADS
 class ComputeLoads(om.Group):
     def initialize(self):
         self.options.declare(
@@ -42,23 +42,23 @@ class ComputeLoads(om.Group):
         }
         self.add_subsystem(
             "gust_loads",
-            RegisterSubmodel.get_submodel(SERVICE_GUST_LOADS),
+            oad.RegisterSubmodel.get_submodel(SERVICE_GUST_LOADS),
             promotes=["*"],
         )
         self.add_subsystem(
             "maneuver_loads",
-            RegisterSubmodel.get_submodel(SERVICE_MANEUVER_LOADS),
+            oad.RegisterSubmodel.get_submodel(SERVICE_MANEUVER_LOADS),
             promotes=["*"],
         )
         self.add_subsystem(
             "sizing_loads_envelope",
-            RegisterSubmodel.get_submodel(
+            oad.RegisterSubmodel.get_submodel(
                 SERVICE_SIZING_LOADS_ENVELOPE, fuel_load_alleviation_option
             ),
             promotes=["*"],
         )
         self.add_subsystem(
             "sizing_loads_max",
-            RegisterSubmodel.get_submodel(SERVICE_SIZING_LOADS_MAX),
+            oad.RegisterSubmodel.get_submodel(SERVICE_SIZING_LOADS_MAX),
             promotes=["*"],
         )

--- a/src/fastoad_cs25/models/loads/loads.py
+++ b/src/fastoad_cs25/models/loads/loads.py
@@ -20,6 +20,7 @@ from .constants import (
     SERVICE_GUST_LOADS,
     SERVICE_MANEUVER_LOADS,
     SERVICE_SIZING_LOADS_ENVELOPE,
+    SERVICE_SIZING_LOADS_MAX,
 )
 
 
@@ -41,16 +42,23 @@ class ComputeLoads(om.Group):
         }
         self.add_subsystem(
             "gust_loads",
-            RegisterSubmodel.get_submodel(SERVICE_GUST_LOADS, fuel_load_alleviation_option),
+            RegisterSubmodel.get_submodel(SERVICE_GUST_LOADS),
             promotes=["*"],
         )
         self.add_subsystem(
             "maneuver_loads",
-            RegisterSubmodel.get_submodel(SERVICE_MANEUVER_LOADS, fuel_load_alleviation_option),
+            RegisterSubmodel.get_submodel(SERVICE_MANEUVER_LOADS),
             promotes=["*"],
         )
         self.add_subsystem(
             "sizing_loads_envelope",
-            RegisterSubmodel.get_submodel(SERVICE_SIZING_LOADS_ENVELOPE),
+            RegisterSubmodel.get_submodel(
+                SERVICE_SIZING_LOADS_ENVELOPE, fuel_load_alleviation_option
+            ),
+            promotes=["*"],
+        )
+        self.add_subsystem(
+            "sizing_loads_max",
+            RegisterSubmodel.get_submodel(SERVICE_SIZING_LOADS_MAX),
             promotes=["*"],
         )

--- a/src/fastoad_cs25/models/loads/sizing_loads/__init__.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/__init__.py
@@ -1,3 +1,4 @@
+"""Python package for evaluating the sizing loads using CS25."""
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify

--- a/src/fastoad_cs25/models/loads/sizing_loads/__init__.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/__init__.py
@@ -1,8 +1,5 @@
-"""
-Test package
-"""
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -13,8 +10,3 @@ Test package
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from pathlib import Path
-
-root_folder_path = Path(__file__).parent.parent
-""" Path of the whole project folder """

--- a/src/fastoad_cs25/models/loads/sizing_loads/gust.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/gust.py
@@ -1,8 +1,8 @@
 """
-Computation of dimensioning load cases
+Python module for the computation of gust sizing load cases.
 """
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,16 +14,16 @@ Computation of dimensioning load cases
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
-from fastoad.module_management.service_registry import RegisterSubmodel
 from scipy.constants import g
 from stdatm import Atmosphere
 
 from ..constants import SERVICE_GUST_LOADS
 
 
-@RegisterSubmodel(SERVICE_GUST_LOADS, "fastoad.submodel.loads.gust.legacy")
+@oad.RegisterSubmodel(SERVICE_GUST_LOADS, "fastoad.submodel.loads.gust.legacy")
 class GustLoads(om.ExplicitComponent):
     """
     Computes CS25 vertical gust loading evaluated at two different load cases:

--- a/src/fastoad_cs25/models/loads/sizing_loads/gust.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/gust.py
@@ -47,11 +47,11 @@ class GustLoads(om.ExplicitComponent):
         self.add_input("data:load_case:lc2:U_gust", val=np.nan, units="m/s")
         self.add_input("data:load_case:lc2:altitude", val=np.nan, units="ft")
         self.add_input("data:load_case:lc2:Vc_EAS", val=np.nan, units="m/s")
-        self.add_input("data:load_case:gust_intensity", val=1.0)
-        self.add_input("data:mission:sizing:cs25:safety_factor", val=1.5)
+        self.add_input("data:load_case:gust_intensity", val=1.0, units="unitless")
+        self.add_input("data:mission:sizing:cs25:safety_factor", val=1.5, units="unitless")
 
-        self.add_output("data:mission:sizing:cs25:gust:load_factor_1")
-        self.add_output("data:mission:sizing:cs25:gust:load_factor_2")
+        self.add_output("data:mission:sizing:cs25:gust:load_factor_1", units="unitless")
+        self.add_output("data:mission:sizing:cs25:gust:load_factor_2", units="unitless")
 
     def setup_partials(self):
         self.declare_partials("data:mission:sizing:cs25:gust:load_factor_1", "*", method="fd")

--- a/src/fastoad_cs25/models/loads/sizing_loads/gust.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/gust.py
@@ -99,7 +99,7 @@ class GustLoads(om.ExplicitComponent):
         alt_2 = inputs["data:load_case:lc2:altitude"]
         vc_eas2 = inputs["data:load_case:lc2:Vc_EAS"]
         gust_intensity = inputs["data:load_case:gust_intensity"]
-        sf = inputs["data:mission:sizing:cs25:safety_factor"]
+        safety_factor = inputs["data:mission:sizing:cs25:safety_factor"]
 
         # calculation of mean geometric chord
         chord_geom = wing_area / span
@@ -116,7 +116,7 @@ class GustLoads(om.ExplicitComponent):
             cl_alpha,
             u_gust1,
         )
-        n1 = sf * n_gust_1 * gust_intensity
+        n1 = safety_factor * n_gust_1 * gust_intensity
 
         # load case #2
         n_gust_2 = self.__n_gust(
@@ -129,7 +129,7 @@ class GustLoads(om.ExplicitComponent):
             cl_alpha,
             u_gust2,
         )
-        n2 = sf * n_gust_2 * gust_intensity
+        n2 = safety_factor * n_gust_2 * gust_intensity
 
         outputs["data:mission:sizing:cs25:gust:load_factor_1"] = n1
         outputs["data:mission:sizing:cs25:gust:load_factor_2"] = n2

--- a/src/fastoad_cs25/models/loads/sizing_loads/maneuver.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/maneuver.py
@@ -1,0 +1,87 @@
+"""
+Computation of dimensioning load cases
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+import openmdao.api as om
+from fastoad.module_management.service_registry import RegisterSubmodel
+from scipy.constants import g
+
+from ..constants import SERVICE_MANEUVER_LOADS
+
+
+@RegisterSubmodel(SERVICE_MANEUVER_LOADS, "fastoad.submodel.loads.maneuver.legacy")
+class ManeuverLoads(om.ExplicitComponent):
+    """
+    Computes CS25 pull-up maneuver evaluated at two different load cases:
+
+    Load case 1: with wings with almost no fuel
+    Load case 2: at maximum take-off weight
+
+    Based on formulas in :cite:`supaero:2014`, §6.3
+
+    """
+
+    def initialize(self):
+        self.options.declare(
+            "fuel_load_alleviation",
+            types=bool,
+            default=True,
+            desc="If False this simulates a dry wing,"
+            "i.e. the sizing load 2 does not take into account the fuel weight.",
+        )
+
+    def setup(self):
+        self.add_input("data:weight:aircraft:MZFW", val=np.nan, units="kg")
+        self.add_input("data:weight:aircraft:MFW", val=np.nan, units="kg")
+        self.add_input("data:weight:aircraft:MTOW", val=np.nan, units="kg")
+        self.add_input("data:load_case:maneuver_load_factor", val=2.5)
+        self.add_input("data:mission:sizing:cs25:safety_factor_1", val=1.5)
+        self.add_input("data:mission:sizing:cs25:safety_factor_2", val=1.5)
+
+        self.add_output("data:mission:sizing:cs25:maneuver:load_factor_1")
+        self.add_output("data:mission:sizing:cs25:maneuver:load_factor_2")
+        self.add_output("data:mission:sizing:cs25:maneuver:sizing_load_1", units="N")
+        self.add_output("data:mission:sizing:cs25:maneuver:sizing_load_2", units="N")
+
+    def setup_partials(self):
+        self.declare_partials("*", "*", method="fd")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        mzfw = inputs["data:weight:aircraft:MZFW"]
+        mfw = inputs["data:weight:aircraft:MFW"]
+        mtow = inputs["data:weight:aircraft:MTOW"]
+        n_maneuver = inputs["data:load_case:maneuver_load_factor"]
+        sf1 = inputs["data:mission:sizing:cs25:safety_factor_1"]
+        sf2 = inputs["data:mission:sizing:cs25:safety_factor_2"]
+
+        # load case #1
+        m1 = 1.05 * mzfw
+        n1 = sf1 * n_maneuver
+        n1m1 = n1 * m1 * g
+
+        # load case #2
+        n2 = sf2 * n_maneuver
+
+        if not self.options["fuel_load_alleviation"]:
+            n2m2 = n2 * mtow * g
+        else:
+            mcv = min(0.8 * mfw, mtow - mzfw)  # fuel mass in the overhanging part of wing
+            n2m2 = n2 * (mtow - 0.55 * mcv) * g
+
+        outputs["data:mission:sizing:cs25:maneuver:load_factor_1"] = n1
+        outputs["data:mission:sizing:cs25:maneuver:load_factor_2"] = n2
+        outputs["data:mission:sizing:cs25:maneuver:sizing_load_1"] = n1m1
+        outputs["data:mission:sizing:cs25:maneuver:sizing_load_2"] = n2m2

--- a/src/fastoad_cs25/models/loads/sizing_loads/maneuver.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/maneuver.py
@@ -1,5 +1,5 @@
 """
-Computation of dimensioning load cases
+Python module for the computation of maneuver sizing load cases.
 """
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2023 ONERA & ISAE-SUPAERO
@@ -14,15 +14,15 @@ Computation of dimensioning load cases
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
-from fastoad.module_management.service_registry import RegisterSubmodel
 from scipy.constants import g
 
 from ..constants import SERVICE_MANEUVER_LOADS
 
 
-@RegisterSubmodel(SERVICE_MANEUVER_LOADS, "fastoad.submodel.loads.maneuver.legacy")
+@oad.RegisterSubmodel(SERVICE_MANEUVER_LOADS, "fastoad.submodel.loads.maneuver.legacy")
 class ManeuverLoads(om.ExplicitComponent):
     """
     Computes CS25 pull-up maneuver evaluated at two different load cases:

--- a/src/fastoad_cs25/models/loads/sizing_loads/maneuver.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/maneuver.py
@@ -56,7 +56,7 @@ class ManeuverLoads(om.ExplicitComponent):
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         n_maneuver = inputs["data:load_case:maneuver_load_factor"]
-        sf = inputs["data:mission:sizing:cs25:safety_factor"]
+        safety_factor = inputs["data:mission:sizing:cs25:safety_factor"]
         mtow = inputs["data:weight:aircraft:MTOW"]
 
         if (
@@ -65,10 +65,10 @@ class ManeuverLoads(om.ExplicitComponent):
             n_maneuver = self.__n_maneuver(mtow)
 
         # load case #1
-        n1 = sf * n_maneuver
+        n1 = safety_factor * n_maneuver
 
         # load case #2
-        n2 = sf * n_maneuver
+        n2 = safety_factor * n_maneuver
 
         outputs["data:mission:sizing:cs25:maneuver:load_factor_1"] = n1
         outputs["data:mission:sizing:cs25:maneuver:load_factor_2"] = n2

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
@@ -11,13 +11,13 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import fastoad.api as oad
 import openmdao.api as om
-from fastoad.module_management.service_registry import RegisterSubmodel
 
 from ..constants import SERVICE_SIZING_LOADS_ENVELOPE
 
 
-@RegisterSubmodel(SERVICE_SIZING_LOADS_ENVELOPE, "fastoad.submodel.loads.envelope.legacy")
+@oad.RegisterSubmodel(SERVICE_SIZING_LOADS_ENVELOPE, "fastoad.submodel.loads.envelope.legacy")
 class SizingLoadsEnvelope(om.ExplicitComponent):
     """
     Computes CS25 sizing loading evaluated at two different load cases:

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
@@ -25,7 +25,7 @@ from ..constants import SERVICE_SIZING_LOADS_ENVELOPE
 @oad.RegisterSubmodel(SERVICE_SIZING_LOADS_ENVELOPE, "fastoad.submodel.loads.envelope.legacy")
 class SizingLoadsEnvelope(om.ExplicitComponent):
     """
-    Computes CS25 sizing loading evaluated at two different load cases:
+    Computes CS25 sizing loads evaluated at two different load cases:
 
     Load case 1: with wings with almost no fuel
     Load case 2: at maximum take-off weight

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
@@ -1,0 +1,65 @@
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+from fastoad.module_management.service_registry import RegisterSubmodel
+
+from ..constants import SERVICE_SIZING_LOADS_ENVELOPE
+
+
+@RegisterSubmodel(SERVICE_SIZING_LOADS_ENVELOPE, "fastoad.submodel.loads.envelope.legacy")
+class SizingLoadsEnvelope(om.ExplicitComponent):
+    """
+    Computes CS25 sizing loading evaluated at two different load cases:
+
+    Load case 1: with wings with almost no fuel
+    Load case 2: at maximum take-off weight
+
+    Based on formulas in :cite:`supaero:2014`, §6.3
+
+    """
+
+    def setup(self):
+        self.add_input("data:mission:sizing:cs25:gust:load_factor_1")
+        self.add_input("data:mission:sizing:cs25:gust:load_factor_2")
+        self.add_input("data:mission:sizing:cs25:gust:sizing_load_1", units="N")
+        self.add_input("data:mission:sizing:cs25:gust:sizing_load_2", units="N")
+        self.add_input("data:mission:sizing:cs25:maneuver:load_factor_1")
+        self.add_input("data:mission:sizing:cs25:maneuver:load_factor_2")
+        self.add_input("data:mission:sizing:cs25:maneuver:sizing_load_1", units="N")
+        self.add_input("data:mission:sizing:cs25:maneuver:sizing_load_2", units="N")
+
+        self.add_output("data:mission:sizing:cs25:load_factor_1")
+        self.add_output("data:mission:sizing:cs25:load_factor_2")
+        self.add_output("data:mission:sizing:cs25:sizing_load_1", units="N")
+        self.add_output("data:mission:sizing:cs25:sizing_load_2", units="N")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        n1_gust = inputs["data:mission:sizing:cs25:gust:load_factor_1"]
+        n2_gust = inputs["data:mission:sizing:cs25:gust:load_factor_2"]
+        n1m1_gust = inputs["data:mission:sizing:cs25:gust:sizing_load_1"]
+        n2m2_gust = inputs["data:mission:sizing:cs25:gust:sizing_load_2"]
+        n1_maneuver = inputs["data:mission:sizing:cs25:maneuver:load_factor_1"]
+        n2_maneuver = inputs["data:mission:sizing:cs25:maneuver:load_factor_2"]
+        n1m1_maneuver = inputs["data:mission:sizing:cs25:maneuver:sizing_load_1"]
+        n2m2_maneuver = inputs["data:mission:sizing:cs25:maneuver:sizing_load_2"]
+
+        n1 = max(n1_gust, n1_maneuver)
+        n2 = max(n2_gust, n2_maneuver)
+        n1m1 = max(n1m1_gust, n1m1_maneuver)
+        n2m2 = max(n2m2_gust, n2m2_maneuver)
+
+        outputs["data:mission:sizing:cs25:load_factor_1"] = n1
+        outputs["data:mission:sizing:cs25:load_factor_2"] = n2
+        outputs["data:mission:sizing:cs25:sizing_load_1"] = n1m1
+        outputs["data:mission:sizing:cs25:sizing_load_2"] = n2m2

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
@@ -1,3 +1,6 @@
+"""
+Python module for the computation of maneuver and gust sizing load case envelope.
+"""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -12,7 +15,9 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import fastoad.api as oad
+import numpy as np
 import openmdao.api as om
+from scipy.constants import g
 
 from ..constants import SERVICE_SIZING_LOADS_ENVELOPE
 
@@ -29,37 +34,100 @@ class SizingLoadsEnvelope(om.ExplicitComponent):
 
     """
 
+    def initialize(self):
+        self.options.declare(
+            "fuel_load_alleviation",
+            types=bool,
+            default=True,
+            desc="If False this simulates a dry wing,"
+            "i.e. the sizing load 2 does not take into account the fuel weight.",
+        )
+
     def setup(self):
+        self.add_input("data:weight:aircraft:MZFW", val=np.nan, units="kg")
+        self.add_input("data:weight:aircraft:MFW", val=np.nan, units="kg")
+        self.add_input("data:weight:aircraft:MTOW", val=np.nan, units="kg")
         self.add_input("data:mission:sizing:cs25:gust:load_factor_1")
         self.add_input("data:mission:sizing:cs25:gust:load_factor_2")
-        self.add_input("data:mission:sizing:cs25:gust:sizing_load_1", units="N")
-        self.add_input("data:mission:sizing:cs25:gust:sizing_load_2", units="N")
         self.add_input("data:mission:sizing:cs25:maneuver:load_factor_1")
         self.add_input("data:mission:sizing:cs25:maneuver:load_factor_2")
-        self.add_input("data:mission:sizing:cs25:maneuver:sizing_load_1", units="N")
-        self.add_input("data:mission:sizing:cs25:maneuver:sizing_load_2", units="N")
 
-        self.add_output("data:mission:sizing:cs25:load_factor_1")
-        self.add_output("data:mission:sizing:cs25:load_factor_2")
-        self.add_output("data:mission:sizing:cs25:sizing_load_1", units="N")
-        self.add_output("data:mission:sizing:cs25:sizing_load_2", units="N")
+        self.add_output("data:mission:sizing:cs25:envelope:max_load_factor_1")
+        self.add_output("data:mission:sizing:cs25:envelope:max_load_factor_2")
+        self.add_output("data:mission:sizing:cs25:envelope:max_sizing_load_1", units="N")
+        self.add_output("data:mission:sizing:cs25:envelope:max_sizing_load_2", units="N")
+
+    def setup_partials(self):
+        self.declare_partials(
+            "data:mission:sizing:cs25:envelope:max_load_factor_1",
+            [
+                "data:mission:sizing:cs25:gust:load_factor_1",
+                "data:mission:sizing:cs25:maneuver:load_factor_1",
+            ],
+            method="fd",
+        )
+        self.declare_partials(
+            "data:mission:sizing:cs25:envelope:max_load_factor_2",
+            [
+                "data:mission:sizing:cs25:gust:load_factor_2",
+                "data:mission:sizing:cs25:maneuver:load_factor_2",
+            ],
+            method="fd",
+        )
+
+        self.declare_partials(
+            "data:mission:sizing:cs25:envelope:max_sizing_load_1",
+            [
+                "data:weight:aircraft:MZFW",
+                "data:weight:aircraft:MFW",
+                "data:weight:aircraft:MTOW",
+                "data:mission:sizing:cs25:gust:load_factor_1",
+                "data:mission:sizing:cs25:maneuver:load_factor_1",
+            ],
+            method="fd",
+        )
+        self.declare_partials(
+            "data:mission:sizing:cs25:envelope:max_sizing_load_2",
+            [
+                "data:weight:aircraft:MZFW",
+                "data:weight:aircraft:MFW",
+                "data:weight:aircraft:MTOW",
+                "data:mission:sizing:cs25:gust:load_factor_2",
+                "data:mission:sizing:cs25:maneuver:load_factor_2",
+            ],
+            method="fd",
+        )
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
-        n1_gust = inputs["data:mission:sizing:cs25:gust:load_factor_1"]
-        n2_gust = inputs["data:mission:sizing:cs25:gust:load_factor_2"]
-        n1m1_gust = inputs["data:mission:sizing:cs25:gust:sizing_load_1"]
-        n2m2_gust = inputs["data:mission:sizing:cs25:gust:sizing_load_2"]
+        mzfw = inputs["data:weight:aircraft:MZFW"]
+        mfw = inputs["data:weight:aircraft:MFW"]
+        mtow = inputs["data:weight:aircraft:MTOW"]
+
         n1_maneuver = inputs["data:mission:sizing:cs25:maneuver:load_factor_1"]
         n2_maneuver = inputs["data:mission:sizing:cs25:maneuver:load_factor_2"]
-        n1m1_maneuver = inputs["data:mission:sizing:cs25:maneuver:sizing_load_1"]
-        n2m2_maneuver = inputs["data:mission:sizing:cs25:maneuver:sizing_load_2"]
+        n1_gust = inputs["data:mission:sizing:cs25:gust:load_factor_1"]
+        n2_gust = inputs["data:mission:sizing:cs25:gust:load_factor_2"]
+
+        # load case #1
+        m1 = 1.05 * mzfw
+        n1m1_maneuver = n1_maneuver * m1 * g
+        n1m1_gust = n1_gust * m1 * g
+
+        # load case #2
+        if not self.options["fuel_load_alleviation"]:
+            n2m2_maneuver = n2_maneuver * mtow * g
+            n2m2_gust = n2_gust * mtow * g
+        else:
+            mcv = min(0.8 * mfw, mtow - mzfw)  # fuel mass in the overhanging part of wing
+            n2m2_maneuver = n2_maneuver * (mtow - 0.55 * mcv) * g
+            n2m2_gust = n2_gust * (mtow - 0.55 * mcv) * g
 
         n1 = max(n1_gust, n1_maneuver)
         n2 = max(n2_gust, n2_maneuver)
         n1m1 = max(n1m1_gust, n1m1_maneuver)
         n2m2 = max(n2m2_gust, n2m2_maneuver)
 
-        outputs["data:mission:sizing:cs25:load_factor_1"] = n1
-        outputs["data:mission:sizing:cs25:load_factor_2"] = n2
-        outputs["data:mission:sizing:cs25:sizing_load_1"] = n1m1
-        outputs["data:mission:sizing:cs25:sizing_load_2"] = n2m2
+        outputs["data:mission:sizing:cs25:envelope:max_load_factor_1"] = n1
+        outputs["data:mission:sizing:cs25:envelope:max_load_factor_2"] = n2
+        outputs["data:mission:sizing:cs25:envelope:max_sizing_load_1"] = n1m1
+        outputs["data:mission:sizing:cs25:envelope:max_sizing_load_2"] = n2m2

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_envelope.py
@@ -47,17 +47,18 @@ class SizingLoadsEnvelope(om.ExplicitComponent):
         self.add_input("data:weight:aircraft:MZFW", val=np.nan, units="kg")
         self.add_input("data:weight:aircraft:MFW", val=np.nan, units="kg")
         self.add_input("data:weight:aircraft:MTOW", val=np.nan, units="kg")
-        self.add_input("data:mission:sizing:cs25:gust:load_factor_1")
-        self.add_input("data:mission:sizing:cs25:gust:load_factor_2")
-        self.add_input("data:mission:sizing:cs25:maneuver:load_factor_1")
-        self.add_input("data:mission:sizing:cs25:maneuver:load_factor_2")
+        self.add_input("data:mission:sizing:cs25:gust:load_factor_1", units="unitless")
+        self.add_input("data:mission:sizing:cs25:gust:load_factor_2", units="unitless")
+        self.add_input("data:mission:sizing:cs25:maneuver:load_factor_1", units="unitless")
+        self.add_input("data:mission:sizing:cs25:maneuver:load_factor_2", units="unitless")
 
-        self.add_output("data:mission:sizing:cs25:envelope:max_load_factor_1")
-        self.add_output("data:mission:sizing:cs25:envelope:max_load_factor_2")
+        self.add_output("data:mission:sizing:cs25:envelope:max_load_factor_1", units="unitless")
+        self.add_output("data:mission:sizing:cs25:envelope:max_load_factor_2", units="unitless")
         self.add_output("data:mission:sizing:cs25:envelope:max_sizing_load_1", units="N")
         self.add_output("data:mission:sizing:cs25:envelope:max_sizing_load_2", units="N")
 
     def setup_partials(self):
+        # Load factor outputs
         self.declare_partials(
             "data:mission:sizing:cs25:envelope:max_load_factor_1",
             [
@@ -75,27 +76,12 @@ class SizingLoadsEnvelope(om.ExplicitComponent):
             method="fd",
         )
 
+        # Sizing load outputs
         self.declare_partials(
-            "data:mission:sizing:cs25:envelope:max_sizing_load_1",
-            [
-                "data:weight:aircraft:MZFW",
-                "data:weight:aircraft:MFW",
-                "data:weight:aircraft:MTOW",
-                "data:mission:sizing:cs25:gust:load_factor_1",
-                "data:mission:sizing:cs25:maneuver:load_factor_1",
-            ],
-            method="fd",
+            "data:mission:sizing:cs25:envelope:max_sizing_load_1", "*", method="fd"
         )
         self.declare_partials(
-            "data:mission:sizing:cs25:envelope:max_sizing_load_2",
-            [
-                "data:weight:aircraft:MZFW",
-                "data:weight:aircraft:MFW",
-                "data:weight:aircraft:MTOW",
-                "data:mission:sizing:cs25:gust:load_factor_2",
-                "data:mission:sizing:cs25:maneuver:load_factor_2",
-            ],
-            method="fd",
+            "data:mission:sizing:cs25:envelope:max_sizing_load_2", "*", method="fd"
         )
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_max.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_max.py
@@ -36,10 +36,7 @@ class SizingLoadsEnvelope(om.ExplicitComponent):
     def setup_partials(self):
         self.declare_partials(
             "data:mission:sizing:cs25:sizing_load",
-            [
-                "data:mission:sizing:cs25:envelope:max_sizing_load_1",
-                "data:mission:sizing:cs25:envelope:max_sizing_load_2",
-            ],
+            "*",
             method="fd",
         )
 
@@ -47,6 +44,6 @@ class SizingLoadsEnvelope(om.ExplicitComponent):
         n1m1 = inputs["data:mission:sizing:cs25:envelope:max_sizing_load_1"]
         n2m2 = inputs["data:mission:sizing:cs25:envelope:max_sizing_load_2"]
 
-        n_m = max(n1m1, n2m2)
+        nm = max(n1m1, n2m2)
 
-        outputs["data:mission:sizing:cs25:sizing_load"] = n_m
+        outputs["data:mission:sizing:cs25:sizing_load"] = nm

--- a/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_max.py
+++ b/src/fastoad_cs25/models/loads/sizing_loads/sizing_loads_max.py
@@ -1,0 +1,52 @@
+"""
+Python module for the computation of the maximum sizing loads.
+"""
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import fastoad.api as oad
+import openmdao.api as om
+
+from ..constants import SERVICE_SIZING_LOADS_MAX
+
+
+@oad.RegisterSubmodel(SERVICE_SIZING_LOADS_MAX, "fastoad.submodel.loads.maximum_sizing.legacy")
+class SizingLoadsEnvelope(om.ExplicitComponent):
+    """
+    Computes CS25 sizing loading
+
+    """
+
+    def setup(self):
+        self.add_input("data:mission:sizing:cs25:envelope:max_sizing_load_1", units="N")
+        self.add_input("data:mission:sizing:cs25:envelope:max_sizing_load_2", units="N")
+
+        self.add_output("data:mission:sizing:cs25:sizing_load", units="N")
+
+    def setup_partials(self):
+        self.declare_partials(
+            "data:mission:sizing:cs25:sizing_load",
+            [
+                "data:mission:sizing:cs25:envelope:max_sizing_load_1",
+                "data:mission:sizing:cs25:envelope:max_sizing_load_2",
+            ],
+            method="fd",
+        )
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        n1m1 = inputs["data:mission:sizing:cs25:envelope:max_sizing_load_1"]
+        n2m2 = inputs["data:mission:sizing:cs25:envelope:max_sizing_load_2"]
+
+        n_m = max(n1m1, n2m2)
+
+        outputs["data:mission:sizing:cs25:sizing_load"] = n_m

--- a/src/fastoad_cs25/models/loads/tests/__init__.py
+++ b/src/fastoad_cs25/models/loads/tests/__init__.py
@@ -1,8 +1,5 @@
-"""
-Test package
-"""
 #  This file is part of FAST-OAD_CS25
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -13,8 +10,3 @@ Test package
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from pathlib import Path
-
-root_folder_path = Path(__file__).parent.parent
-""" Path of the whole project folder """

--- a/src/fastoad_cs25/models/loads/tests/data/mass_breakdown_inputs.xml
+++ b/src/fastoad_cs25/models/loads/tests/data/mass_breakdown_inputs.xml
@@ -1,0 +1,382 @@
+<!--
+  ~ This file is part of FAST-OAD_CS25
+  ~ Copyright (C) 2022 ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<FASTOAD_model>
+  <data>
+    <TLAR>
+      <NPAX>150.0<!--top-level requirement: number of passengers, assuming a classic eco/business class repartition--></NPAX>
+      <range units="NM">2750.0<!--top-level requirement: design range--></range>
+    </TLAR>
+    <geometry>
+      <has_T_tail>0.0<!--0=horizontal tail is attached to fuselage / 1=horizontal tail is attached to top of vertical tail--></has_T_tail>
+      <aircraft>
+        <wetted_area units="m**2">784.007<!--total wetted area--></wetted_area>
+      </aircraft>
+      <cabin>
+        <NPAX1>157.0<!--number of passengers if there are only economical class seats--></NPAX1>
+        <length units="m">30.0056<!--cabin length--></length>
+        <pallet_count>10.0<!--number of pallet in cargo hold--></pallet_count>
+        <containers>
+          <count>5.0<!--total number of cargo containers--></count>
+          <count_by_row>1.0<!--number of cargo containers along width--></count_by_row>
+        </containers>
+        <crew_count>
+          <commercial>4.0<!--number of commercial crew members--></commercial>
+          <technical>2.0<!--number of technical crew members--></technical>
+        </crew_count>
+        <seats>
+          <economical>
+            <count_by_row>6.0<!--number of economical class seats along width--></count_by_row>
+          </economical>
+        </seats>
+      </cabin>
+      <fuselage>
+        <front_length units="m">6.902<!--length of front non-cylindrical part of the fuselage--></front_length>
+        <length units="m">37.507<!--total fuselage length--></length>
+        <maximum_height units="m">4.06<!--maximum fuselage height--></maximum_height>
+        <maximum_width units="m">3.92<!--maximum fuselage width--></maximum_width>
+        <rear_length units="m">14.616<!--length of rear non-cylindrical part of the fuselage--></rear_length>
+        <wetted_area units="m**2">401.956<!--wetted area of fuselage--></wetted_area>
+      </fuselage>
+      <horizontal_tail>
+        <area units="m**2">35.171<!--horizontal tail area--></area>
+      </horizontal_tail>
+      <propulsion>
+        <layout>1.0<!--position of engines (1=under the wing / 2=rear fuselage)--></layout>
+        <engine>
+          <count>2.0<!--number of engines--></count>
+        </engine>
+        <nacelle>
+          <diameter units="m">2.172<!--nacelle diameter--></diameter>
+        </nacelle>
+        <pylon>
+          <wetted_area units="m**2">7.563<!--wetted area of pylon--></wetted_area>
+        </pylon>
+      </propulsion>
+      <vertical_tail>
+        <area units="m**2">25.118<!--vertical tail area--></area>
+      </vertical_tail>
+      <wing>
+        <area units="m**2">124.843<!--wing reference area--></area>
+        <b_50 units="m">34.166<!--actual length between root and tip along 50% of chord--></b_50>
+        <outer_area units="m**2">100.303<!--wing area outside of fuselage--></outer_area>
+        <span units="m">31.603<!--wing span--></span>
+        <sweep_0 units="deg">27.554<!--sweep angle at leading edge of wing--></sweep_0>
+        <sweep_25 units="deg">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
+        <kink>
+          <thickness_ratio>0.121<!--thickness ratio at wing kink--></thickness_ratio>
+        </kink>
+        <root>
+          <chord units="m">6.26<!--chord length at wing root--></chord>
+          <thickness_ratio>0.159<!--thickness ratio at wing root--></thickness_ratio>
+        </root>
+        <tip>
+          <thickness_ratio>0.11<!--thickness ratio at wing tip--></thickness_ratio>
+        </tip>
+      </wing>
+    </geometry>
+    <propulsion>
+      <MTO_thrust units="N">117880.0<!--maximum thrust of one engine at sea level--></MTO_thrust>
+    </propulsion>
+    <load_case>
+      <gust_intensity>0.0</gust_intensity>
+      <lc1>
+        <U_gust units="m/s">15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
+        <Vc_EAS units="kn">375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
+        <altitude units="ft">20000.0<!--altitude for sizing load case 1 (gust with minimum aircraft mass)--></altitude>
+      </lc1>
+      <lc2>
+        <U_gust units="m/s">15.25<!--gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)--></U_gust>
+        <Vc_EAS units="kn">375.0<!--equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)--></Vc_EAS>
+        <altitude units="ft">20000.0<!--altitude for sizing load case 2 (gust with maximum aircraft mass)--></altitude>
+      </lc2>
+    </load_case>
+    <weight>
+      <aircraft>
+        <MFW units="kg">20569.81<!--maximum fuel weight--></MFW>
+        <MLW units="kg">64870.14<!--maximum landing weight--></MLW>
+        <MTOW units="kg">75797.99<!--maximum takeoff weight--></MTOW>
+        <MZFW units="kg">61198.25<!--maximum zero fuel weight--></MZFW>
+        <max_payload units="kg">25000.0<!--max payload weight--></max_payload>
+      </aircraft>
+    </weight>
+    <aerodynamics>
+      <aircraft>
+        <cruise>
+          <CL_alpha>6.2<!--derivative of lift coefficient with respect to angle of attack in cruise conditions--></CL_alpha>
+        </cruise>
+      </aircraft>
+    </aerodynamics>
+  </data>
+  <settings>
+    <weight>
+      <airframe>
+        <flight_controls>
+          <mass>
+            <k_fc>0.000135<!--flight controls (A4): 0.85e-4 if electrical, 1.35e-4 if conventional--></k_fc>
+          </mass>
+        </flight_controls>
+        <fuselage>
+          <mass>
+            <k_fus>1.0<!--correction coefficient: 1.00 if all engines under wing / 1.02 with 2 engines at rear / 1.03 if 3 engines at rear / 1.05 if 1 engine in vertical tail (with or without 2 engines under wing)--></k_fus>
+            <k_lg>1.05<!--correction coefficient: 1.05 if main landing gear under wing / 1.10 if main landing gear under fuselage--></k_lg>
+          </mass>
+        </fuselage>
+        <wing>
+          <mass>
+            <k_mvo>1.39<!--1.39 for Airbus type aircrafts--></k_mvo>
+            <k_voil>1.05<!--1.00 if 4 engines / 1.05 if 2 or 3 engines / 1.10 if engines on fuselage--></k_voil>
+          </mass>
+        </wing>
+      </airframe>
+      <systems>
+        <power>
+          <mass>
+            <k_elec>1.0<!--electricity coefficient: 1.00 if 2 engines (A300, A310 type) / (1.02 if 2 engines (DC9, Caravelle type) / 1.03 if 3 engines (B727 type) / 1.05 if 3 engines (DC10, L1011 type) / 1.08 if 4 engines (B747 type)--></k_elec>
+          </mass>
+        </power>
+      </systems>
+    </weight>
+  </settings>
+  <tuning>
+    <weight>
+      <aircraft>
+        <mlw_mzfw_ratio>1.06<!--empiric ratio used for evaluate the MLW from the MZFW--></mlw_mzfw_ratio>
+      </aircraft>
+      <airframe>
+        <flight_controls>
+          <mass>
+            <k>1.0<!--flight controls (A4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--flight controls (A4): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </flight_controls>
+        <fuselage>
+          <mass>
+            <k>1.1<!--fuselage (A2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--fuselage (A2): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </fuselage>
+        <horizontal_tail>
+          <mass>
+            <k>1.08<!--horizontal tail (A31): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--horizontal tail (A31): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </horizontal_tail>
+        <landing_gear>
+          <mass>
+            <k>0.85<!--landing gears (A5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--landing gears (A5): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </landing_gear>
+        <paint>
+          <mass>
+            <k>1.0<!--paint (A7): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--paint (A7): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </paint>
+        <pylon>
+          <mass>
+            <k>0.85<!--pylon (A6): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--pylon (A6): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </pylon>
+        <vertical_tail>
+          <mass>
+            <k>1.0<!--vertical tail (A32): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--vertical tail (A32): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </vertical_tail>
+        <wing>
+          <mass>
+            <k>1.05<!--wing (A1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--wing (A1): correction offset to be applied on computed mass--></offset>
+          </mass>
+          <bending_sizing>
+            <mass>
+              <k>1.0<!--wing bending sizing (A11): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--wing bending sizing (A11): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </bending_sizing>
+          <reinforcements>
+            <mass>
+              <k>1.0<!--wing reinforcements (A14): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--wing reinforcements (A14): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </reinforcements>
+          <ribs>
+            <mass>
+              <k>1.0<!--wing ribs (A13): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--wing ribs (A13): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </ribs>
+          <secondary_parts>
+            <mass>
+              <k>1.0<!--wing secondary parts (A15): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--wing secondary parts (A15): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </secondary_parts>
+          <shear_sizing>
+            <mass>
+              <k>1.0<!--wing shear sizing (A12): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--wing shear sizing (A12): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </shear_sizing>
+        </wing>
+      </airframe>
+      <furniture>
+        <cargo_configuration>
+          <mass>
+            <k>1.0<!--cargo configuration (D1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--cargo configuration (D1): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </cargo_configuration>
+        <food_water>
+          <mass>
+            <k>1.0<!--food water (D3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--food water (D3): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </food_water>
+        <passenger_seats>
+          <mass>
+            <k>1.0<!--passenger seats (D2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--passenger seats (D2): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </passenger_seats>
+        <security_kit>
+          <mass>
+            <k>1.0<!--security kit (D4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--security kit (D4): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </security_kit>
+        <toilets>
+          <mass>
+            <k>1.0<!--toilets (D5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--toilets (D5): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </toilets>
+      </furniture>
+      <propulsion>
+        <engine>
+          <mass>
+            <k>1.0<!--engine (B1): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--engine (B1): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </engine>
+        <fuel_lines>
+          <mass>
+            <k>1.0<!--fuel lines (B2): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--fuel lines (B2): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </fuel_lines>
+        <unconsumables>
+          <mass>
+            <k>1.0<!--unconsumables (B3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--unconsumables (B3): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </unconsumables>
+      </propulsion>
+      <systems>
+        <flight_kit>
+          <mass>
+            <k>1.0<!--flight kit (C6): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--flight kit (C6): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </flight_kit>
+        <navigation>
+          <mass>
+            <k>1.0<!--navigation (C3): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--navigation (C3): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </navigation>
+        <operational>
+          <mass>
+            <k>1.0<!--operational (C5): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--operational (C5): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </operational>
+        <transmission>
+          <mass>
+            <k>1.0<!--transmission (C4): correction ratio to be applied on computed mass--></k>
+            <offset units="kg">0.0<!--transmission (C4): correction offset to be applied on computed mass--></offset>
+          </mass>
+        </transmission>
+        <life_support>
+          <air_conditioning>
+            <mass>
+              <k>1.0<!--air conditioning (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--air conditioning (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </air_conditioning>
+          <cabin_lighting>
+            <mass>
+              <k>1.0<!--cabin lighting (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--cabin lighting (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </cabin_lighting>
+          <de-icing>
+            <mass>
+              <k>1.0<!--de-icing (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--de-icing (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </de-icing>
+          <insulation>
+            <mass>
+              <k>2.0<!--insulation (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--insulation (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </insulation>
+          <oxygen>
+            <mass>
+              <k>1.0<!--oxygen (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--oxygen (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </oxygen>
+          <safety_equipment>
+            <mass>
+              <k>1.0<!--safety equipment (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--safety equipment (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </safety_equipment>
+          <seats_crew_accommodation>
+            <mass>
+              <k>1.0<!--seats crew accommodation (C21): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--seats crew accommodation (C21): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </seats_crew_accommodation>
+        </life_support>
+        <power>
+          <auxiliary_power_unit>
+            <mass>
+              <k>1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </auxiliary_power_unit>
+          <electric_systems>
+            <mass>
+              <k>1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </electric_systems>
+          <hydraulic_systems>
+            <mass>
+              <k>1.0<!--power (C1): correction ratio to be applied on computed mass--></k>
+              <offset units="kg">0.0<!--power (C1): correction offset to be applied on computed mass--></offset>
+            </mass>
+          </hydraulic_systems>
+        </power>
+      </systems>
+    </weight>
+  </tuning>
+</FASTOAD_model>

--- a/src/fastoad_cs25/models/loads/tests/test_loads.py
+++ b/src/fastoad_cs25/models/loads/tests/test_loads.py
@@ -1,5 +1,5 @@
 """
-Test module for load functions
+Test module for load functions.
 """
 #  This file is part of FAST-OAD_CS25
 #  Copyright (C) 2025 ONERA & ISAE-SUPAERO
@@ -42,8 +42,8 @@ def get_indep_var_comp(var_names):
         (20000, 2.88),  # in-between value
     ],
 )
-def test__n_manouver(w_kg, expected):
-    result = ManeuverLoads._ManeuverLoads__n_manouver(w_kg)
+def test__n_maneuver(w_kg, expected):
+    result = ManeuverLoads._ManeuverLoads__n_maneuver(w_kg)
     assert result == pytest.approx(expected, abs=0.01)
 
 

--- a/src/fastoad_cs25/models/loads/tests/test_loads.py
+++ b/src/fastoad_cs25/models/loads/tests/test_loads.py
@@ -1,0 +1,93 @@
+"""
+Test module for load functions
+"""
+#  This file is part of FAST-OAD_CS25
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+import pytest
+from fastoad.io import VariableIO
+from fastoad.testing import run_system
+from scipy.constants import g
+
+from ..loads import ComputeLoads
+
+
+def get_indep_var_comp(var_names):
+    """Reads required input data and returns an IndepVarcomp() instance"""
+    reader = VariableIO(Path(__file__).parent / "data" / "mass_breakdown_inputs.xml")
+    reader.path_separator = ":"
+    ivc = reader.read(only=var_names).to_ivc()
+    return ivc
+
+
+def test_compute_loads():
+    """Tests computation of sizing loads"""
+    input_list = [
+        "data:geometry:wing:area",
+        "data:geometry:wing:span",
+        "data:weight:aircraft:MZFW",
+        "data:weight:aircraft:MFW",
+        "data:weight:aircraft:MTOW",
+        "data:aerodynamics:aircraft:cruise:CL_alpha",
+        "data:load_case:lc1:U_gust",
+        "data:load_case:lc1:altitude",
+        "data:load_case:lc1:Vc_EAS",
+        "data:load_case:lc2:U_gust",
+        "data:load_case:lc2:altitude",
+        "data:load_case:lc2:Vc_EAS",
+    ]
+    ivc = get_indep_var_comp(input_list)
+    ivc.add_output("data:load_case:gust_intensity", val=0.5)
+    problem = run_system(ComputeLoads(), ivc)
+
+    n1m1 = problem["data:mission:sizing:cs25:sizing_load_1"]
+    n2m2 = problem["data:mission:sizing:cs25:sizing_load_2"]
+    n1 = problem["data:mission:sizing:cs25:load_factor_1"]
+    n2 = problem["data:mission:sizing:cs25:load_factor_2"]
+    assert n1m1 == pytest.approx(240968 * g, abs=10)
+    assert n2m2 == pytest.approx(254130 * g, abs=10)
+    assert n1 == pytest.approx(3.75, abs=0.01)
+    assert n2 == pytest.approx(3.75, abs=0.01)
+
+    # Now without fuel alleviation
+    problem = run_system(ComputeLoads(fuel_load_alleviation=False), ivc)
+
+    n1m1 = problem["data:mission:sizing:cs25:sizing_load_1"]
+    n2m2 = problem["data:mission:sizing:cs25:sizing_load_2"]
+
+    assert n1m1 == pytest.approx(240968 * g, abs=10)
+    assert n2m2 == pytest.approx(284242 * g, abs=10)
+
+    # Now with different maneuver load factor
+    ivc.add_output("data:load_case:maneuver_load_factor", val=2.25)
+    problem = run_system(ComputeLoads(), ivc)
+
+    n1 = problem["data:mission:sizing:cs25:load_factor_1"]
+    n2 = problem["data:mission:sizing:cs25:load_factor_2"]
+    assert n1 == pytest.approx(3.375, abs=0.01)
+    assert n2 == pytest.approx(3.375, abs=0.01)
+
+    # Now without gust load alleviation
+    ivc = get_indep_var_comp(input_list)
+    problem = run_system(ComputeLoads(), ivc)
+
+    n1 = problem["data:mission:sizing:cs25:load_factor_1"]
+    n2 = problem["data:mission:sizing:cs25:load_factor_2"]
+    n1m1 = problem["data:mission:sizing:cs25:sizing_load_1"]
+    n2m2 = problem["data:mission:sizing:cs25:sizing_load_2"]
+    assert n1 == pytest.approx(4.198, abs=0.01)
+    assert n2 == pytest.approx(3.81, abs=0.01)
+    assert n1m1 == pytest.approx(269848 * g, abs=10)
+    assert n2m2 == pytest.approx(258553 * g, abs=10)

--- a/src/fastoad_cs25/models/loads/tests/test_loads.py
+++ b/src/fastoad_cs25/models/loads/tests/test_loads.py
@@ -23,6 +23,7 @@ from scipy.constants import g
 
 from ..loads import ComputeLoads
 from ..sizing_loads.gust import GustLoads
+from ..sizing_loads.maneuver import ManeuverLoads
 
 
 def get_indep_var_comp(var_names):
@@ -31,6 +32,19 @@ def get_indep_var_comp(var_names):
     reader.path_separator = ":"
     ivc = reader.read(only=var_names).to_ivc()
     return ivc
+
+
+@pytest.mark.parametrize(
+    "w_kg, expected",
+    [
+        (1000, 3.8),  # very low weight, should clip to max 3.8
+        (100000, 2.5),  # high weight, should clip to min 2.5
+        (20000, 2.88),  # in-between value
+    ],
+)
+def test__n_manouver(w_kg, expected):
+    result = ManeuverLoads._ManeuverLoads__n_manouver(w_kg)
+    assert result == pytest.approx(expected, abs=0.01)
 
 
 def test_gust_load_factor():

--- a/src/fastoad_cs25/models/loops/compute_wing_position.py
+++ b/src/fastoad_cs25/models/loops/compute_wing_position.py
@@ -16,7 +16,6 @@ Computation of wing position
 
 import numpy as np
 import openmdao.api as om
-
 from fastoad.module_management.constants import ModelDomain
 from fastoad.module_management.service_registry import RegisterOpenMDAOSystem
 

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -195,7 +195,7 @@ data:load_case:lc1:altitude || altitude for sizing load case 1 (gust with minimu
 data:load_case:lc2:U_gust || gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)
 data:load_case:lc2:Vc_EAS || equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)
 data:load_case:lc2:altitude || altitude for sizing load case 2 (gust with maximum aircraft mass)
-data:load_case:maneuver_load_factor || limit positive manoeuvring load factor (pull-up)
+data:load_case:maneuver_load_factor || desired limit positive manoeuvring load factor (pull-up). If 0.0: evalued using CS 25.337
 data:load_case:gust_intensity || a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated
 data:mission:sizing:cs25:envelope:max_load_factor_1 || max between gust and positive manoeuvring load factor for sizing load case 1
 data:mission:sizing:cs25:envelope:max_load_factor_2 || max between gust and positive manoeuvring load factor for sizing load case 2
@@ -203,8 +203,8 @@ data:mission:sizing:cs25:envelope:max_sizing_load_1 || wing load for load case 1
 data:mission:sizing:cs25:envelope:max_sizing_load_2 || wing load for load case 2 (gust with maximum aircraft mass)
 data:mission:sizing:cs25:gust:load_factor_1 || gust load factor for sizing load case 1
 data:mission:sizing:cs25:gust:load_factor_2 || gust load factor for sizing load case 2
-data:mission:sizing:cs25:maneuver:load_factor_1 || positive manoeuvring load factor for sizing load case 1
-data:mission:sizing:cs25:maneuver:load_factor_2 || positive manoeuvring load factor for sizing load case 2
+data:mission:sizing:cs25:maneuver:load_factor_1 || positive manoeuvring load factor for sizing load case 1 with safety factor
+data:mission:sizing:cs25:maneuver:load_factor_2 || positive manoeuvring load factor for sizing load case 2 with safety factor
 data:mission:sizing:cs25:safety_factor || safety factor for sizing load cases
 data:mission:sizing:cs25:sizing_load || maximum sizing load 
 data:propulsion:MTO_thrust || maximum thrust of one engine at sea level

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -195,8 +195,14 @@ data:load_case:lc1:altitude || altitude for sizing load case 1 (gust with minimu
 data:load_case:lc2:U_gust || gust vertical speed for sizing load case 2 (gust with maximum aircraft mass)
 data:load_case:lc2:Vc_EAS || equivalent air speed for sizing load case 2 (gust with maximum aircraft mass)
 data:load_case:lc2:altitude || altitude for sizing load case 2 (gust with maximum aircraft mass)
-data:load_case:manoeuvre_load_factor || limit positive manoeuvring load factor
+data:load_case:maneuver_load_factor || limit positive manoeuvring load factor (pull-up)
 data:load_case:gust_intensity || a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated
+data:mission:sizing:cs25:load_factor_1 || max between gust and positive manoeuvring load factor for sizing load case 1
+data:mission:sizing:cs25:load_factor_2 || max between gust and positive manoeuvring load factor for sizing load case 2
+data:mission:sizing:cs25:safety_factor_1 || safety factor for sizing load case 1 (gust with minimum aircraft mass) 
+data:mission:sizing:cs25:safety_factor_2 || safety factor for sizing load case 2 (gust with maximum aircraft mass)
+data:mission:sizing:cs25:sizing_load_1 || sizing load for load case 1 (gust with minimum aircraft mass)
+data:mission:sizing:cs25:sizing_load_2 || sizing load for load case 2 (gust with maximum aircraft mass)
 data:propulsion:MTO_thrust || maximum thrust of one engine at sea level
 data:propulsion:SFC || Specific Fuel Consumption (can be a vector)
 data:propulsion:altitude || altitude for propulsion calculation (can be a vector)

--- a/src/fastoad_cs25/models/variable_descriptions.txt
+++ b/src/fastoad_cs25/models/variable_descriptions.txt
@@ -197,12 +197,16 @@ data:load_case:lc2:Vc_EAS || equivalent air speed for sizing load case 2 (gust w
 data:load_case:lc2:altitude || altitude for sizing load case 2 (gust with maximum aircraft mass)
 data:load_case:maneuver_load_factor || limit positive manoeuvring load factor (pull-up)
 data:load_case:gust_intensity || a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated
-data:mission:sizing:cs25:load_factor_1 || max between gust and positive manoeuvring load factor for sizing load case 1
-data:mission:sizing:cs25:load_factor_2 || max between gust and positive manoeuvring load factor for sizing load case 2
-data:mission:sizing:cs25:safety_factor_1 || safety factor for sizing load case 1 (gust with minimum aircraft mass) 
-data:mission:sizing:cs25:safety_factor_2 || safety factor for sizing load case 2 (gust with maximum aircraft mass)
-data:mission:sizing:cs25:sizing_load_1 || sizing load for load case 1 (gust with minimum aircraft mass)
-data:mission:sizing:cs25:sizing_load_2 || sizing load for load case 2 (gust with maximum aircraft mass)
+data:mission:sizing:cs25:envelope:max_load_factor_1 || max between gust and positive manoeuvring load factor for sizing load case 1
+data:mission:sizing:cs25:envelope:max_load_factor_2 || max between gust and positive manoeuvring load factor for sizing load case 2
+data:mission:sizing:cs25:envelope:max_sizing_load_1 || wing load for load case 1 (gust with minimum aircraft mass)
+data:mission:sizing:cs25:envelope:max_sizing_load_2 || wing load for load case 2 (gust with maximum aircraft mass)
+data:mission:sizing:cs25:gust:load_factor_1 || gust load factor for sizing load case 1
+data:mission:sizing:cs25:gust:load_factor_2 || gust load factor for sizing load case 2
+data:mission:sizing:cs25:maneuver:load_factor_1 || positive manoeuvring load factor for sizing load case 1
+data:mission:sizing:cs25:maneuver:load_factor_2 || positive manoeuvring load factor for sizing load case 2
+data:mission:sizing:cs25:safety_factor || safety factor for sizing load cases
+data:mission:sizing:cs25:sizing_load || maximum sizing load 
 data:propulsion:MTO_thrust || maximum thrust of one engine at sea level
 data:propulsion:SFC || Specific Fuel Consumption (can be a vector)
 data:propulsion:altitude || altitude for propulsion calculation (can be a vector)

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
@@ -17,6 +17,7 @@ Estimation of wing weight
 import numpy as np
 import openmdao.api as om
 from fastoad.module_management.service_registry import RegisterSubmodel
+from scipy.constants import g
 
 from .constants import SERVICE_WING_MASS
 
@@ -50,8 +51,8 @@ class WingWeight(om.ExplicitComponent):
         self.add_input("data:geometry:propulsion:layout", val=np.nan)
         self.add_input("data:weight:aircraft:MTOW", val=np.nan, units="kg")
         self.add_input("data:weight:aircraft:MLW", val=np.nan, units="kg")
-        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="kg")
-        self.add_input("data:mission:sizing:cs25:sizing_load_2", val=np.nan, units="kg")
+        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="N")
+        self.add_input("data:mission:sizing:cs25:sizing_load_2", val=np.nan, units="N")
         self.add_input("tuning:weight:airframe:wing:mass:k", val=1.0)
         self.add_input("tuning:weight:airframe:wing:mass:offset", val=0.0, units="kg")
         self.add_input("tuning:weight:airframe:wing:bending_sizing:mass:k", val=1.0)
@@ -88,9 +89,12 @@ class WingWeight(om.ExplicitComponent):
         cantilevered_area = inputs["data:geometry:wing:outer_area"]
         mtow = inputs["data:weight:aircraft:MTOW"]
         mlw = inputs["data:weight:aircraft:MLW"]
-        max_nm = max(
-            inputs["data:mission:sizing:cs25:sizing_load_1"],
-            inputs["data:mission:sizing:cs25:sizing_load_2"],
+        max_nm = (
+            max(
+                inputs["data:mission:sizing:cs25:sizing_load_1"],
+                inputs["data:mission:sizing:cs25:sizing_load_2"],
+            )
+            / g
         )
         engine_count = inputs["data:geometry:propulsion:engine:count"]
         engine_on_fuselage = inputs["data:geometry:propulsion:layout"] == 2

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
@@ -51,8 +51,7 @@ class WingWeight(om.ExplicitComponent):
         self.add_input("data:geometry:propulsion:layout", val=np.nan)
         self.add_input("data:weight:aircraft:MTOW", val=np.nan, units="kg")
         self.add_input("data:weight:aircraft:MLW", val=np.nan, units="kg")
-        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="N")
-        self.add_input("data:mission:sizing:cs25:sizing_load_2", val=np.nan, units="N")
+        self.add_input("data:mission:sizing:cs25:sizing_load", val=np.nan, units="N")
         self.add_input("tuning:weight:airframe:wing:mass:k", val=1.0)
         self.add_input("tuning:weight:airframe:wing:mass:offset", val=0.0, units="kg")
         self.add_input("tuning:weight:airframe:wing:bending_sizing:mass:k", val=1.0)
@@ -89,13 +88,7 @@ class WingWeight(om.ExplicitComponent):
         cantilevered_area = inputs["data:geometry:wing:outer_area"]
         mtow = inputs["data:weight:aircraft:MTOW"]
         mlw = inputs["data:weight:aircraft:MLW"]
-        max_nm = (
-            max(
-                inputs["data:mission:sizing:cs25:sizing_load_1"],
-                inputs["data:mission:sizing:cs25:sizing_load_2"],
-            )
-            / g
-        )
+        max_nm = inputs["data:mission:sizing:cs25:sizing_load"] / g
         engine_count = inputs["data:geometry:propulsion:engine:count"]
         engine_on_fuselage = inputs["data:geometry:propulsion:layout"] == 2
         if engine_on_fuselage:

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
@@ -17,6 +17,7 @@ Estimation of fuselage weight
 import numpy as np
 import openmdao.api as om
 from fastoad.module_management.service_registry import RegisterSubmodel
+from scipy.constants import g
 
 from .constants import SERVICE_FUSELAGE_MASS
 
@@ -33,7 +34,7 @@ class FuselageWeight(om.ExplicitComponent):
         self.add_input("data:geometry:fuselage:wetted_area", val=np.nan, units="m**2")
         self.add_input("data:geometry:fuselage:maximum_width", val=np.nan, units="m")
         self.add_input("data:geometry:fuselage:maximum_height", val=np.nan, units="m")
-        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="kg")
+        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="N")
         self.add_input("tuning:weight:airframe:fuselage:mass:k", val=1.0)
         self.add_input("tuning:weight:airframe:fuselage:mass:offset", val=0.0, units="kg")
         self.add_input("settings:weight:airframe:fuselage:mass:k_lg", val=1.05)
@@ -56,7 +57,7 @@ class FuselageWeight(om.ExplicitComponent):
 
         temp_a2 = (
             fuselage_wet_area
-            * (10 + 1.2 * np.sqrt(width_max * height_max) + 0.00019 * n1m1 / height_max**1.7)
+            * (10 + 1.2 * np.sqrt(width_max * height_max) + 0.00019 * n1m1 / g / height_max**1.7)
             * k_lg
             * k_fus
         )

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
@@ -34,7 +34,7 @@ class FuselageWeight(om.ExplicitComponent):
         self.add_input("data:geometry:fuselage:wetted_area", val=np.nan, units="m**2")
         self.add_input("data:geometry:fuselage:maximum_width", val=np.nan, units="m")
         self.add_input("data:geometry:fuselage:maximum_height", val=np.nan, units="m")
-        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="N")
+        self.add_input("data:mission:sizing:cs25:envelope:max_sizing_load_1", val=np.nan, units="N")
         self.add_input("tuning:weight:airframe:fuselage:mass:k", val=1.0)
         self.add_input("tuning:weight:airframe:fuselage:mass:offset", val=0.0, units="kg")
         self.add_input("settings:weight:airframe:fuselage:mass:k_lg", val=1.05)
@@ -49,7 +49,7 @@ class FuselageWeight(om.ExplicitComponent):
         fuselage_wet_area = inputs["data:geometry:fuselage:wetted_area"]
         width_max = inputs["data:geometry:fuselage:maximum_width"]
         height_max = inputs["data:geometry:fuselage:maximum_height"]
-        n1m1 = inputs["data:mission:sizing:cs25:sizing_load_1"]
+        n1m1 = inputs["data:mission:sizing:cs25:envelope:max_sizing_load_1"]
         k_a2 = inputs["tuning:weight:airframe:fuselage:mass:k"]
         offset_a2 = inputs["tuning:weight:airframe:fuselage:mass:offset"]
         k_lg = inputs["settings:weight:airframe:fuselage:mass:k_lg"]

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
@@ -17,6 +17,7 @@ Estimation of flight controls weight
 import numpy as np
 import openmdao.api as om
 from fastoad.module_management.service_registry import RegisterSubmodel
+from scipy.constants import g
 
 from .constants import SERVICE_FLIGHT_CONTROLS_MASS
 
@@ -34,8 +35,8 @@ class FlightControlsWeight(om.ExplicitComponent):
     def setup(self):
         self.add_input("data:geometry:fuselage:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:b_50", val=np.nan, units="m")
-        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="kg")
-        self.add_input("data:mission:sizing:cs25:sizing_load_2", val=np.nan, units="kg")
+        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="N")
+        self.add_input("data:mission:sizing:cs25:sizing_load_2", val=np.nan, units="N")
         self.add_input(
             "settings:weight:airframe:flight_controls:mass:k_fc", val=0.85
         )  # FIXME: this one should depend on a boolan electric/not-electric flight_controls
@@ -54,9 +55,12 @@ class FlightControlsWeight(om.ExplicitComponent):
         k_a4 = inputs["tuning:weight:airframe:flight_controls:mass:k"]
         offset_a4 = inputs["tuning:weight:airframe:flight_controls:mass:offset"]
 
-        max_nm = max(
-            inputs["data:mission:sizing:cs25:sizing_load_1"],
-            inputs["data:mission:sizing:cs25:sizing_load_2"],
+        max_nm = (
+            max(
+                inputs["data:mission:sizing:cs25:sizing_load_1"],
+                inputs["data:mission:sizing:cs25:sizing_load_2"],
+            )
+            / g
         )
 
         temp_a4 = k_fc * max_nm * (fus_length**0.66 + b_50**0.66)

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
@@ -35,8 +35,7 @@ class FlightControlsWeight(om.ExplicitComponent):
     def setup(self):
         self.add_input("data:geometry:fuselage:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:b_50", val=np.nan, units="m")
-        self.add_input("data:mission:sizing:cs25:sizing_load_1", val=np.nan, units="N")
-        self.add_input("data:mission:sizing:cs25:sizing_load_2", val=np.nan, units="N")
+        self.add_input("data:mission:sizing:cs25:sizing_load", val=np.nan, units="N")
         self.add_input(
             "settings:weight:airframe:flight_controls:mass:k_fc", val=0.85
         )  # FIXME: this one should depend on a boolan electric/not-electric flight_controls
@@ -55,13 +54,7 @@ class FlightControlsWeight(om.ExplicitComponent):
         k_a4 = inputs["tuning:weight:airframe:flight_controls:mass:k"]
         offset_a4 = inputs["tuning:weight:airframe:flight_controls:mass:offset"]
 
-        max_nm = (
-            max(
-                inputs["data:mission:sizing:cs25:sizing_load_1"],
-                inputs["data:mission:sizing:cs25:sizing_load_2"],
-            )
-            / g
-        )
+        max_nm = inputs["data:mission:sizing:cs25:sizing_load"] / g
 
         temp_a4 = k_fc * max_nm * (fus_length**0.66 + b_50**0.66)
 

--- a/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/sum.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/a_airframe/sum.py
@@ -15,6 +15,7 @@
 import openmdao.api as om
 from fastoad.module_management.service_registry import RegisterSubmodel
 
+from ..constants import SERVICE_AIRFRAME_MASS
 from .constants import (
     SERVICE_EMPENNAGE_MASS,
     SERVICE_FLIGHT_CONTROLS_MASS,
@@ -24,7 +25,6 @@ from .constants import (
     SERVICE_PYLONS_MASS,
     SERVICE_WING_MASS,
 )
-from ..constants import SERVICE_AIRFRAME_MASS, SERVICE_GUST_LOADS
 
 
 @RegisterSubmodel(SERVICE_AIRFRAME_MASS, "fastoad.submodel.weight.mass.airframe.legacy")
@@ -35,9 +35,6 @@ class AirframeWeight(om.Group):
 
     def setup(self):
         # Airframe
-        self.add_subsystem(
-            "loads", RegisterSubmodel.get_submodel(SERVICE_GUST_LOADS), promotes=["*"]
-        )
         self.add_subsystem(
             "wing_weight", RegisterSubmodel.get_submodel(SERVICE_WING_MASS), promotes=["*"]
         )

--- a/src/fastoad_cs25/models/weight/mass_breakdown/constants.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/constants.py
@@ -20,5 +20,3 @@ SERVICE_PROPULSION_MASS = "service.mass.propulsion"
 SERVICE_SYSTEMS_MASS = "service.mass.systems"
 SERVICE_FURNITURE_MASS = "service.mass.furniture"
 SERVICE_CREW_MASS = "service.mass.crew"
-
-SERVICE_GUST_LOADS = "service.gust_loads"

--- a/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -598,7 +598,7 @@ def test_loop_compute_oew():
         "sizing_loads", ComputeLoads(), promotes=["*"]
     )  # need to plug load evaluation
     group.add_subsystem("mass_breakdown", MassBreakdown(), promotes=["*"])
-    mass_computation = run_system(group, input_vars)
+    mass_computation = run_system(group, input_vars, nonlinear_solver="om.NonlinearBlockGS")
     oew = mass_computation["data:weight:aircraft:OWE"]
     assert oew == pytest.approx(41591, abs=1)
 
@@ -611,6 +611,6 @@ def test_loop_compute_oew():
     group = Group()
     group.add_subsystem("sizing_loads", ComputeLoads(), promotes=["*"])
     group.add_subsystem("mass_breakdown", MassBreakdown(payload_from_npax=False), promotes=["*"])
-    mass_computation = run_system(group, input_vars)
+    mass_computation = run_system(group, input_vars, nonlinear_solver="om.NonlinearBlockGS")
     oew = mass_computation["data:weight:aircraft:OWE"]
     assert oew == pytest.approx(42060, abs=1)

--- a/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -111,8 +111,7 @@ def test_compute_wing_weight():
     ]
 
     ivc = get_indep_var_comp(input_list)
-    ivc.add_output("data:mission:sizing:cs25:sizing_load_1", 241000 * g, units="N")
-    ivc.add_output("data:mission:sizing:cs25:sizing_load_2", 250000 * g, units="N")
+    ivc.add_output("data:mission:sizing:cs25:sizing_load", 250000 * g, units="N")
 
     problem = run_system(WingWeight(), ivc)
 
@@ -133,7 +132,7 @@ def test_compute_fuselage_weight():
     ]
 
     ivc = get_indep_var_comp(input_list)
-    ivc.add_output("data:mission:sizing:cs25:sizing_load_1", 241000 * g, units="N")
+    ivc.add_output("data:mission:sizing:cs25:envelope:max_sizing_load_1", 241000 * g, units="N")
 
     problem = run_system(FuselageWeight(), ivc)
 
@@ -172,8 +171,7 @@ def test_compute_flight_controls_weight():
         "settings:weight:airframe:flight_controls:mass:k_fc",
     ]
     ivc = get_indep_var_comp(input_list)
-    ivc.add_output("data:mission:sizing:cs25:sizing_load_1", 241000 * g, units="N")
-    ivc.add_output("data:mission:sizing:cs25:sizing_load_2", 250000 * g, units="N")
+    ivc.add_output("data:mission:sizing:cs25:sizing_load", 250000 * g, units="N")
     problem = run_system(FlightControlsWeight(), ivc)
 
     val = problem["data:weight:airframe:flight_controls:mass"]

--- a/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad_cs25/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -601,8 +601,6 @@ def test_loop_compute_oew():
     assert oew == pytest.approx(41591, abs=1)
 
     # with payload as input
-    reader = VariableIO(Path(__file__).parent / "data" / "mass_breakdown_inputs.xml")
-    reader.path_separator = ":"
     input_vars = reader.read(
         ignore=["data:weight:aircraft:MLW", "data:weight:aircraft:MZFW"]
     ).to_ivc()

--- a/src/fastoad_cs25/notebooks/01_tutorial/data/CeRAS01_baseline.xml
+++ b/src/fastoad_cs25/notebooks/01_tutorial/data/CeRAS01_baseline.xml
@@ -365,10 +365,10 @@
                         0.93<!--thrust rate (between 0.0 and 1.0) during climb phase in sizing mission--></thrust_rate>
                 </climb>
                 <cs25>
-                    <sizing_load_1 units="kg">
-                        241541.87594825038<!--sizing load during gust with minimum aircraft mass--></sizing_load_1>
-                    <sizing_load_2 units="kg">
-                        251847.8282255141<!--sizing load during gust with maximum aircraft mass--></sizing_load_2>
+                    <sizing_load_1 units="N">
+                        2368716.6377679096<!--sizing load during gust with minimum aircraft mass--></sizing_load_1>
+                    <sizing_load_2 units="N">
+                        2469783.5046677375<!--sizing load during gust with maximum aircraft mass--></sizing_load_2>
                 </cs25>
                 <descent>
                     <thrust_rate>

--- a/src/fastoad_cs25/notebooks/01_tutorial/data/oad_process_timestep_mission.yml
+++ b/src/fastoad_cs25/notebooks/01_tutorial/data/oad_process_timestep_mission.yml
@@ -33,6 +33,8 @@ model:
       id: fastoad.geometry.legacy
     weight:
       id: fastoad.weight.legacy
+    loads:
+      id: fastoad.loads.legacy
     mtow:
       id: fastoad.mass_performances.compute_MTOW
     hq_tail_sizing:

--- a/src/fastoad_cs25/notebooks/02_CeRAS_case_study/data/oad_sizing.yml
+++ b/src/fastoad_cs25/notebooks/02_CeRAS_case_study/data/oad_sizing.yml
@@ -18,6 +18,8 @@ model:
   weight:
     id: fastoad.weight.legacy
     payload_from_npax: false
+  loads:
+    id: fastoad.loads.legacy
   mtow:
     id: fastoad.mass_performances.compute_MTOW
   aerodynamics_highspeed:

--- a/src/fastoad_cs25/notebooks/02_CeRAS_case_study/data/oad_sizing_out.xml
+++ b/src/fastoad_cs25/notebooks/02_CeRAS_case_study/data/oad_sizing_out.xml
@@ -416,8 +416,8 @@
       </SPP_study>
       <sizing>
         <cs25>
-          <sizing_load_1 units="kg" is_input="False">242582.07752640772<!--sizing load during gust with minimum aircraft mass--></sizing_load_1>
-          <sizing_load_2 units="kg" is_input="False">258291.37897705915<!--sizing load during gust with maximum aircraft mass--></sizing_load_2>
+          <sizing_load_1 units="N" is_input="False">2378917.530574346<!--sizing load during gust with minimum aircraft mass--></sizing_load_1>
+          <sizing_load_2 units="N" is_input="False">2532973.151645377<!--sizing load during gust with maximum aircraft mass--></sizing_load_2>
         </cs25>
         <landing>
           <flap_angle units="deg" is_input="True">30.0<!--flap angle during landing phase in sizing mission--></flap_angle>

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
@@ -142,7 +142,7 @@
         <root>
           <chord units="m" is_input="False">6.128838026153156<!--chord length at root of vertical tail--></chord>
           <leading_edge>
-            <x units="m" is_input="False">29.477739872847263<local units="m" is_input="False">4.440892098500626e-16<!--X-position of leading edge at vertical tail tip w.r.t. leading edge of root chord--></local></x>
+            <x units="m" is_input="False">29.477739872847263<local units="m" is_input="False">-0.0<!--X-position of leading edge at vertical tail tip w.r.t. leading edge of root chord--></local></x>
           </leading_edge>
         </root>
         <tip>
@@ -222,7 +222,7 @@
     </handling_qualities>
     <load_case>
       <gust_intensity is_input="True">0.5<!--a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated--></gust_intensity>
-      <manoeuvre_load_factor is_input="True">2.5<!--limit positive manoeuvring load factor--></manoeuvre_load_factor>
+      <maneuver_load_factor is_input="True">2.5<!--limit positive manoeuvring load factor--></maneuver_load_factor>
       <lc1>
         <U_gust units="m/s" is_input="True">15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
         <Vc_EAS units="m/s" is_input="True">375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
@@ -261,8 +261,8 @@
         <cs25>
           <load_factor_1 is_input="False">3.75</load_factor_1>
           <load_factor_2 is_input="False">3.75</load_factor_2>
-          <sizing_load_1 units="kg" is_input="False">246422.77051970272</sizing_load_1>
-          <sizing_load_2 units="kg" is_input="False">259162.77666729141</sizing_load_2>
+          <sizing_load_1 units="N" is_input="False">2416581.8625170426</sizing_load_1>
+          <sizing_load_2 units="N" is_input="False">2541518.643804293</sizing_load_2>
         </cs25>
         <global_reserve>
           <distance units="m" is_input="False">0.0<!--covered ground distance during route "global_reserve" in mission "sizing"--></distance>
@@ -324,7 +324,7 @@
         <MTOW units="kg" is_input="False">77086.92304594585<!--maximum takeoff weight--></MTOW>
         <MZFW units="kg" is_input="False">62583.560782701934<!--maximum zero fuel weight--></MZFW>
         <OWE units="kg" is_input="False">42975.560782701934<!--Mass of crew--></OWE>
-        <additional_fuel_capacity units="kg" is_input="False">-7.358954462688416e-06<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
+        <additional_fuel_capacity units="kg" is_input="False">0.000011<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
         <max_payload units="kg" is_input="False">19608.0<!--max payload weight--></max_payload>
         <payload units="kg" is_input="False">13608.0<!--_inp_data:weight:aircraft:payload--></payload>
         <sizing_block_fuel units="kg" is_input="False">20503.362270602855<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>

--- a/tests/integration_tests/oad_process/data/no_kink_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/no_kink_breguet_result.xml
@@ -82,7 +82,7 @@
         <center>
           <chord units="m" is_input="False">4.362840133313165<!--chord length at center of horizontal tail--></chord>
           <leading_edge>
-            <x units="m" is_input="False">31.71477312903165<!--_inp_data:geometry:horizontal_tail:center:leading_edge:x--><local units="m" is_input="False">-2.220446049250313e-16<!--X-position of the leading edge at center of horizontal tail w.r.t. leading edge of center chord--></local></x>
+            <x units="m" is_input="False">31.71477312903165<!--_inp_data:geometry:horizontal_tail:center:leading_edge:x--><local units="m" is_input="False">-0.0<!--X-position of the leading edge at center of horizontal tail w.r.t. leading edge of center chord--></local></x>
           </leading_edge>
         </center>
         <tip>
@@ -222,7 +222,7 @@
     </handling_qualities>
     <load_case>
       <gust_intensity is_input="True">0.0<!--a factor for gust load alleviation, 1.0: full gust load is applied, 0.0: gust load is fully alleviated--></gust_intensity>
-      <manoeuvre_load_factor is_input="True">2.5<!--limit positive manoeuvring load factor--></manoeuvre_load_factor>
+      <maneuver_load_factor is_input="True">2.5<!--limit positive manoeuvring load factor--></maneuver_load_factor>
       <lc1>
         <U_gust units="m/s" is_input="True">15.25<!--gust vertical speed for sizing load case 1 (gust with minimum aircraft mass)--></U_gust>
         <Vc_EAS units="m/s" is_input="True">375.0<!--equivalent air speed for sizing load case 1 (gust with minimum aircraft mass)--></Vc_EAS>
@@ -261,8 +261,8 @@
         <cs25>
           <load_factor_1 is_input="False">3.75</load_factor_1>
           <load_factor_2 is_input="False">3.75</load_factor_2>
-          <sizing_load_1 units="kg" is_input="False">249254.59066519403</sizing_load_1>
-          <sizing_load_2 units="kg" is_input="False">262309.19884847995</sizing_load_2>
+          <sizing_load_1 units="N" is_input="False">2444352.531546825</sizing_load_1>
+          <sizing_load_2 units="N" is_input="False">2572374.504887446</sizing_load_2>
         </cs25>
         <global_reserve>
           <distance units="m" is_input="False">0.0<!--covered ground distance during route "global_reserve" in mission "sizing"--></distance>
@@ -324,7 +324,7 @@
         <MTOW units="kg" is_input="False">78072.45659716826<!--maximum takeoff weight--></MTOW>
         <MZFW units="kg" is_input="False">63302.75321510128<!--maximum zero fuel weight--></MZFW>
         <OWE units="kg" is_input="False">43694.75321510128<!--Mass of crew--></OWE>
-        <additional_fuel_capacity units="kg" is_input="False">-1.389114186167717e-05<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
+        <additional_fuel_capacity units="kg" is_input="False">-0.000013<!--fuel mass capacity of wing that exceeds sizing mission requirement--></additional_fuel_capacity>
         <max_payload units="kg" is_input="False">19608.0<!--max payload weight--></max_payload>
         <payload units="kg" is_input="False">13608.0<!--_inp_data:weight:aircraft:payload--></payload>
         <sizing_block_fuel units="kg" is_input="False">20769.703395958124<!--block fuel quantity (i.e. loaded before taxi-out) used for sizing process--></sizing_block_fuel>

--- a/tests/integration_tests/oad_process/data/oad_process.yml
+++ b/tests/integration_tests/oad_process/data/oad_process.yml
@@ -6,7 +6,7 @@ input_file: ../results/oad_process_inputs.xml
 output_file: ../results/oad_process_outputs.xml
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-3)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2)
   linear_solver: om.DirectSolver()
   geometry:
     id: fastoad.geometry.legacy

--- a/tests/integration_tests/oad_process/data/oad_process.yml
+++ b/tests/integration_tests/oad_process/data/oad_process.yml
@@ -6,12 +6,14 @@ input_file: ../results/oad_process_inputs.xml
 output_file: ../results/oad_process_outputs.xml
 
 model:
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2)
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-3)
   linear_solver: om.DirectSolver()
   geometry:
     id: fastoad.geometry.legacy
   weight:
     id: fastoad.weight.legacy
+  loads:
+    id: fastoad.loads.legacy
   mtow:
     id: fastoad.mass_performances.compute_MTOW
   aerodynamics:

--- a/tests/integration_tests/oad_process/data/oad_process_breguet.yml
+++ b/tests/integration_tests/oad_process/data/oad_process_breguet.yml
@@ -12,6 +12,8 @@ model:
     id: fastoad.geometry.legacy
   weight:
     id: fastoad.weight.legacy
+  loads:
+    id: fastoad.loads.legacy
   mtow:
     id: fastoad.mass_performances.compute_MTOW
   aerodynamics:

--- a/tests/integration_tests/oad_process/data/oad_process_mission.yml
+++ b/tests/integration_tests/oad_process/data/oad_process_mission.yml
@@ -24,6 +24,8 @@ model:
       use_xfoil: false
     weight:
       id: fastoad.weight.legacy
+    loads:
+      id: fastoad.loads.legacy
     mtow:
       id: fastoad.mass_performances.compute_MTOW
     hq:

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -66,9 +66,9 @@ def test_oad_process(cleanup):
 
     RESULTS_FOLDER_PATH.mkdir(parents=True, exist_ok=True)
     om.view_connections(
-        problem, outfile=str(RESULTS_FOLDER_PATH / "connections.html"), show_browser=False
+        problem, outfile=(RESULTS_FOLDER_PATH / "connections.html").as_posix(), show_browser=False
     )
-    om.n2(problem, outfile=str(RESULTS_FOLDER_PATH / "n2.html"), show_browser=False)
+    om.n2(problem, outfile=(RESULTS_FOLDER_PATH / "n2.html").as_posix(), show_browser=False)
 
     # Check that weight-performances loop correctly converged
     _check_weight_performance_loop(problem)
@@ -192,7 +192,7 @@ def run_non_regression_test(
     problem.write_outputs()
 
     om.view_connections(
-        problem, outfile=str(results_folder_path / "connections.html"), show_browser=False
+        problem, outfile=(results_folder_path / "connections.html").as_posix(), show_browser=False
     )
 
     if check_weight_perfo_loop:


### PR DESCRIPTION
# Separation of CS25 Load Evaluation into Dedicated Discipline

## Summary

This PR introduces a major refactor aimed at improving modularity and clarity in the CS25 sizing loads evaluation, which was previously embedded in the `weight` discipline.

We now isolate the load evaluation logic into a dedicated discipline, setting the foundation for future expansions or specialized module development.

---

## Structural Refactor

The core of this PR is the moving and decomposition of the former monolithic sizing load module into three focused submodules:

- `gust.py`: evaluates vertical gust loads according to CS25  
- `maneuver.py`: computes loads for pull-up maneuvers
- `sizing_loads_envelope.py`: combines the above into a sizing envelope evaluating the max 

---

## Additional Fixes and Improvements

- **Removed hardcoded `9.81` in __n_gust static method**  
  Replaced with `scipy.constants.g` for clarity and correctness  
  _Breaking Change_: test results slightly differ, tests updated accordingly

- **Switched from kilograms (kg) to Newtons (N)** for all sizing load values  
  Avoids the potentially misleading use of “equivalent kg”  
  _Breaking Change_: affects XML outputs

- **British to American manoeuvre or maneuver correction**  
  Previously there was a mix of the two; now aligned with American standard maneuver 
  _Breaking Change_: some variable names updated

- **Introduced explicit safety factor control**  
  New variables added for the evaluation of the n for the two sizing load cases, defaulting to 1.5

- **Improved integration tests**  
  Updated to use `pathlib` for modern and OS-independent path handling

- **Added missing entries to `variable_description.txt`**

- **Added `skip_if_no_xfoil` tag to the pyproject.toml to remove some pytest warnings **

---

## Breaking Changes Summary

1. Gust load expression now uses `scipy.constants.g`
2. Loads are now expressed in Newtons, not equivalent kg
3. Switch from British to American maneuver load 

---

PS In loads.py I would like to add the domain ModelDomain.LOADS, but it is not yet released in FASTOAD core. I wrote a TODO to add it.