### PR TITLE
Now the cg eval is ok even when the engine is positioned after the kink

### DIFF
--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -231,8 +231,7 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         ) / (chord2.y - chord1.y)
         delta_x_nacelle = 0.05 * chord_at_engine_location
         x_nacelle_cg = (
-            chord1.x
-            + (chord2.x - chord1.x) * (y_nacelle - chord1.y) / (chord2.y - chord1.y)
+            np.interp(y_nacelle, [chord1.y, chord2.y], [chord1.x, chord2.x])
             - delta_x_nacelle
             - 0.2 * nacelle.length
         )

--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -171,7 +171,7 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         propulsion_layout = np.round(inputs["data:geometry:propulsion:layout"])
         root_chord = Chord(
-            x=None,
+            x=0.0,
             y=inputs["data:geometry:wing:root:y"],
             length=inputs["data:geometry:wing:root:chord"],
         )
@@ -231,7 +231,8 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         ) / (chord2.y - chord1.y)
         delta_x_nacelle = 0.05 * chord_at_engine_location
         x_nacelle_cg = (
-            chord2.x * (y_nacelle - chord1.y) / (chord2.y - chord1.y)
+            chord1.x
+            + (chord2.x - chord1.x) * (y_nacelle - chord1.y) / (chord2.y - chord1.y)
             - delta_x_nacelle
             - 0.2 * nacelle.length
         )

--- a/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
+from fastoad._utils.arrays import scalarize
 
 from ...constants import SERVICE_NACELLE_PYLON_GEOMETRY
 
@@ -171,19 +172,19 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         propulsion_layout = np.round(inputs["data:geometry:propulsion:layout"])
         root_chord = Chord(
-            x=0.0,
-            y=inputs["data:geometry:wing:root:y"],
-            length=inputs["data:geometry:wing:root:chord"],
+            x=scalarize(0.0),
+            y=scalarize(inputs["data:geometry:wing:root:y"]),
+            length=scalarize(inputs["data:geometry:wing:root:chord"]),
         )
         kink_chord = Chord(
-            x=inputs["data:geometry:wing:kink:leading_edge:x:local"],
-            y=inputs["data:geometry:wing:kink:y"],
-            length=inputs["data:geometry:wing:kink:chord"],
+            x=scalarize(inputs["data:geometry:wing:kink:leading_edge:x:local"]),
+            y=scalarize(inputs["data:geometry:wing:kink:y"]),
+            length=scalarize(inputs["data:geometry:wing:kink:chord"]),
         )
         tip_chord = Chord(
-            x=inputs["data:geometry:wing:tip:leading_edge:x:local"],
-            y=inputs["data:geometry:wing:tip:y"],
-            length=inputs["data:geometry:wing:tip:chord"],
+            x=scalarize(inputs["data:geometry:wing:tip:leading_edge:x:local"]),
+            y=scalarize(inputs["data:geometry:wing:tip:y"]),
+            length=scalarize(inputs["data:geometry:wing:tip:chord"]),
         )
 
         nacelle = Nacelle(inputs["data:propulsion:MTO_thrust"])


### PR DESCRIPTION
This pull request makes a fix to the calculation of the nacelle CG x-position in the `compute_nacelle_pylons.py` module. The key change is a correction to the interpolation formula for `x_nacelle_cg`, ensuring the x-position is accurately interpolated between `chord1` and `chord2` instead of using only `chord2.x`.