### PR TITLE
Add minimal value to virtual root chord based on span

### DIFF
--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -70,7 +70,7 @@ class ComputeL1AndL4Wing(om.ExplicitComponent):
             _LOGGER.warning(
                 "Computed root virtual chord is non-positive : %f; using 5%% of span "
                 "as a fallback.",
-                l1_wing,
+                l1_wing[0],
             )
             l1_wing = span * 0.05
         l4_wing = l1_wing * virtual_taper_ratio

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -14,9 +14,13 @@ Estimation of wing chords (l1 and l4)
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import logging
+
 import numpy as np
 import openmdao.api as om
 from fastoad.api import ValidityDomainChecker
+
+_LOGGER = logging.getLogger(__name__)  # Logger for this module
 
 
 @ValidityDomainChecker(
@@ -63,6 +67,11 @@ class ComputeL1AndL4Wing(om.ExplicitComponent):
         )
 
         if l1_wing <= 0.0:
+            _LOGGER.warning(
+                "Computed root virtual chord is non-positive : %f; using 5%% of span "
+                "as a fallback.",
+                l1_wing,
+            )
             l1_wing = span * 0.05
         l4_wing = l1_wing * virtual_taper_ratio
 

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -62,6 +62,8 @@ class ComputeL1AndL4Wing(om.ExplicitComponent):
             / (2.0 * (span - 2 * y2_wing))
         )
 
+        if l1_wing <= 0.0:
+            l1_wing = span * 0.05
         l4_wing = l1_wing * virtual_taper_ratio
 
         outputs["data:geometry:wing:root:virtual_chord"] = l1_wing

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -68,9 +68,8 @@ class ComputeL1AndL4Wing(om.ExplicitComponent):
 
         if l1_wing <= 0.0:
             _LOGGER.warning(
-                "Computed root virtual chord is non-positive : %f; using 5%% of span "
-                "as a fallback.",
-                l1_wing[0],
+                "Computed root virtual chord is non-positive. Using 5%% of span "
+                "as a fallback. This is likely a transient effect."
             )
             l1_wing = span * 0.05
         l4_wing = l1_wing * virtual_taper_ratio

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -85,10 +85,12 @@ def test_geometry_wing_l1_l4():
 
 
 def test_correction_for_negative_l1(caplog):
-    """Test that when an unfeasible wing geometry is inputed and results
+    """
+    Test that when an unfeasible wing geometry is inputed and results
     in a negative chord value, the virtual chord value is set to a default
-    value of 5% of wingspan. Unfeasible geometries concerned especially wings
-    with high aspect ratio, far lateral kink, and high sweep, low inner-kink trailing sweep."""
+    value of 5% of wingspan. Unfeasible geometries are affected, especially wings
+    with high aspect ratio, far lateral kink, and high sweep, low inner-kink trailing sweep.
+    """
 
     input_vars = om.IndepVarComp()
     input_vars.add_output("data:geometry:wing:area", 50, units="m**2")

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -84,7 +84,7 @@ def test_geometry_wing_l1_l4():
     assert wing_l4 == pytest.approx(1.882, abs=1e-3)
 
 
-def test_correction_for_negative_l1():
+def test_correction_for_negative_l1(caplog):
     """Test that when an unfeasible wing geometry is inputed and results
     in a negative chord value, the virtual chord value is set to a default
     value of 5% of wingspan. Unfeasible geometries concerned especially wings
@@ -104,6 +104,12 @@ def test_correction_for_negative_l1():
     expected_wing_l1 = 0.05 * wing_span
 
     assert wing_l1 == pytest.approx(expected_wing_l1, abs=1e-3)
+    expected_core = (
+        "Computed root virtual chord is non-positive. Using 5%% of span "
+        "as a fallback. This is likely a transient effect."
+    )
+
+    assert expected_core in caplog.text, f"Expected warning not found in logs. Logs: {caplog.text}"
 
 
 def test_geometry_wing_l2_l3():

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -84,7 +84,7 @@ def test_geometry_wing_l1_l4():
     assert wing_l4 == pytest.approx(1.882, abs=1e-3)
 
 
-def test_activation_warning_for_negative_l1(caplog):
+def test_correction_for_negative_l1():
     """Test if a warning is generated when an unfeasible wing geometry is input and results
     in a negative chord value. Unfeasible geometries concerned especially wings with high aspect
     ratio, far lateral kink, and high sweep, low inner-kink trailing sweep."""
@@ -100,11 +100,7 @@ def test_activation_warning_for_negative_l1(caplog):
     problem = run_system(ComputeL1AndL4Wing(), input_vars)
     wing_l1 = problem["data:geometry:wing:root:virtual_chord"]
 
-    # Check for the core part of the warning message
-    expected_core = (
-        f'"data:geometry:wing:root:virtual_chord" out of bound: value [{wing_l1[0]:.8f}] m'
-    )
-    assert expected_core in caplog.text, f"Expected warning not found in logs. Logs: {caplog.text}"
+    assert wing_l1 == pytest.approx(15.8015 * 2 * 0.05, abs=1e-3)
 
 
 def test_geometry_wing_l2_l3():

--- a/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
+++ b/src/fastoad_cs25/models/geometry/geom_components/wing/components/tests/test_wing_geom_comps.py
@@ -85,9 +85,10 @@ def test_geometry_wing_l1_l4():
 
 
 def test_correction_for_negative_l1():
-    """Test if a warning is generated when an unfeasible wing geometry is input and results
-    in a negative chord value. Unfeasible geometries concerned especially wings with high aspect
-    ratio, far lateral kink, and high sweep, low inner-kink trailing sweep."""
+    """Test that when an unfeasible wing geometry is inputed and results
+    in a negative chord value, the virtual chord value is set to a default
+    value of 5% of wingspan. Unfeasible geometries concerned especially wings
+    with high aspect ratio, far lateral kink, and high sweep, low inner-kink trailing sweep."""
 
     input_vars = om.IndepVarComp()
     input_vars.add_output("data:geometry:wing:area", 50, units="m**2")
@@ -98,9 +99,11 @@ def test_correction_for_negative_l1():
     input_vars.add_output("data:geometry:wing:tip:y", 15.8015, units="m")
 
     problem = run_system(ComputeL1AndL4Wing(), input_vars)
-    wing_l1 = problem["data:geometry:wing:root:virtual_chord"]
+    wing_l1 = problem.get_val("data:geometry:wing:root:virtual_chord", units="m")
+    wing_span = 2.0 * problem.get_val("data:geometry:wing:tip:y", units="m")
+    expected_wing_l1 = 0.05 * wing_span
 
-    assert wing_l1 == pytest.approx(15.8015 * 2 * 0.05, abs=1e-3)
+    assert wing_l1 == pytest.approx(expected_wing_l1, abs=1e-3)
 
 
 def test_geometry_wing_l2_l3():


### PR DESCRIPTION

This pull request introduces a safeguard to the computation of the wing root virtual chord in the `compute_l1_l4.py` module. The main change ensures that the calculated value for `l1_wing` (the wing root virtual chord) is never zero or negative, which could cause downstream errors in geometric computations. With the initial value of sweep_inner_100 being 0, it may indeed happen that 
for high aspect ratio, to respect the surface area of the wing the virtual chord has to be negative. 

Key improvement to calculation robustness:

* Added a check to set `l1_wing` to 5% of the wing span if the calculated value is less than or equal to zero, preventing invalid or non-physical results in wing geometry calculations.