### PR TITLE
Removed scipy interp1d

### DIFF
--- a/src/fastoad_cs25/models/geometry/profiles/profile.py
+++ b/src/fastoad_cs25/models/geometry/profiles/profile.py
@@ -20,7 +20,7 @@ from typing import Sequence, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy.interpolate import interp1d
+from scipy.interpolate import make_interp_spline
 
 Coordinates2D = namedtuple("Coordinates2D", ["x", "y"])
 
@@ -170,8 +170,8 @@ class Profile:
             .reset_index(drop=True)
         )
 
-        interp_lower = interp1d(lower_side_points[X], lower_side_points[Z], kind="quadratic")
-        interp_upper = interp1d(upper_side_points[X], upper_side_points[Z], kind="quadratic")
+        interp_lower = make_interp_spline(lower_side_points[X], lower_side_points[Z], k=2)
+        interp_upper = make_interp_spline(upper_side_points[X], upper_side_points[Z], k=2)
         z_sides = pd.DataFrame({"z_lower": interp_lower(x), "z_upper": interp_upper(x)})
         z = z_sides.mean(axis=1)
         thickness = z_sides.diff(axis=1).iloc[:, -1]

--- a/src/fastoad_cs25/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
+++ b/src/fastoad_cs25/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
@@ -17,6 +17,7 @@ from typing import Optional, Sequence, Tuple, Union
 
 import numpy as np
 import pandas as pd
+from fastoad._utils.arrays import scalarize
 from fastoad.constants import EngineSetting
 from fastoad.exceptions import FastUnknownEngineSettingError
 from fastoad.model_base import FlightPoint
@@ -129,8 +130,8 @@ class RubberEngine(AbstractFuelPropulsion):
             flight_points.altitude,
             [-1000.0, 0.0, 13106.4, 20000.0],
             np.hstack((self.k_sfc_sl, self.k_sfc_sl, self.k_sfc_cr, self.k_sfc_cr)),
-            left=self.k_sfc_sl,
-            right=self.k_sfc_cr,
+            left=scalarize(self.k_sfc_sl),
+            right=scalarize(self.k_sfc_cr),
         )
 
         flight_points.sfc = sfc * k_sfc

--- a/src/fastoad_cs25/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
+++ b/src/fastoad_cs25/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
@@ -21,7 +21,6 @@ from fastoad.constants import EngineSetting
 from fastoad.exceptions import FastUnknownEngineSettingError
 from fastoad.model_base import FlightPoint
 from fastoad.model_base.propulsion import AbstractFuelPropulsion
-from scipy.interpolate import interp1d
 from stdatm import Atmosphere
 
 from .constants import (
@@ -126,13 +125,13 @@ class RubberEngine(AbstractFuelPropulsion):
                     flight_points.insert(len(flight_points.columns), name, value=np.nan)
 
         # SFC correction for NEO engines dependent on altitude.
-        k_sfc_alt = interp1d(
+        k_sfc = np.interp(
+            flight_points.altitude,
             [-1000.0, 0.0, 13106.4, 20000.0],
             np.hstack((self.k_sfc_sl, self.k_sfc_sl, self.k_sfc_cr, self.k_sfc_cr)),
-            bounds_error=False,
-            fill_value=(self.k_sfc_sl, self.k_sfc_cr),
+            left=self.k_sfc_sl,
+            right=self.k_sfc_cr,
         )
-        k_sfc = k_sfc_alt(flight_points.altitude)
 
         flight_points.sfc = sfc * k_sfc
         flight_points.thrust_rate = thrust_rate

--- a/src/fastoad_cs25/models/weight/cg/cg_components/compute_cg_control_surfaces.py
+++ b/src/fastoad_cs25/models/weight/cg/cg_components/compute_cg_control_surfaces.py
@@ -17,7 +17,6 @@ Estimation of control surfaces center of gravity
 import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
-from scipy.interpolate import interp1d
 
 from ..constants import SERVICE_FLIGHT_CONTROLS_CG
 
@@ -73,10 +72,8 @@ class ComputeControlSurfacesCG(om.ExplicitComponent):
             ]
         )
 
-        x_interp = interp1d(y_values, x_values)
-        x_leading_edge = x_interp(inputs["data:geometry:wing:MAC:y"])
-        l_interp = interp1d(y_values, l_values)
-        l_cg_control = l_interp(inputs["data:geometry:wing:MAC:y"])
+        x_leading_edge = np.interp(inputs["data:geometry:wing:MAC:y"], y_values, x_values)
+        l_cg_control = np.interp(inputs["data:geometry:wing:MAC:y"], y_values, l_values)
         x_cg_control = x_leading_edge + l_cg_control
 
         outputs["data:weight:airframe:flight_controls:CG:x"] = (

--- a/src/fastoad_cs25/models/weight/cg/cg_components/compute_cg_control_surfaces.py
+++ b/src/fastoad_cs25/models/weight/cg/cg_components/compute_cg_control_surfaces.py
@@ -71,9 +71,13 @@ class ComputeControlSurfacesCG(om.ExplicitComponent):
                 inputs["data:geometry:wing:tip:chord"],
             ]
         )
+        sort_idx = np.argsort(y_values)
+        y_sorted = y_values[sort_idx]
+        x_sorted = x_values[sort_idx]
+        l_sorted = l_values[sort_idx]
 
-        x_leading_edge = np.interp(inputs["data:geometry:wing:MAC:y"], y_values, x_values)
-        l_cg_control = np.interp(inputs["data:geometry:wing:MAC:y"], y_values, l_values)
+        x_leading_edge = np.interp(inputs["data:geometry:wing:MAC:y"], y_sorted, x_sorted)
+        l_cg_control = np.interp(inputs["data:geometry:wing:MAC:y"], y_sorted, l_sorted)
         x_cg_control = x_leading_edge + l_cg_control
 
         outputs["data:weight:airframe:flight_controls:CG:x"] = (

--- a/src/fastoad_cs25/models/weight/cg/cg_components/compute_cg_tanks.py
+++ b/src/fastoad_cs25/models/weight/cg/cg_components/compute_cg_tanks.py
@@ -17,7 +17,6 @@ Estimation of tanks center of gravity
 import fastoad.api as oad
 import numpy as np
 import openmdao.api as om
-from scipy import interpolate
 
 from fastoad_cs25.models.geometry.profiles.profile_getter import get_profile
 
@@ -212,4 +211,4 @@ class ComputeTanksCG(om.ExplicitComponent):
         relative_thickness = profile.get_relative_thickness()
         relative_x_scale = relative_thickness.x
         thickness = relative_thickness.thickness * l2_wing
-        return interpolate.interp1d(relative_x_scale, thickness)(relative_x)
+        return np.interp(relative_x, relative_x_scale, thickness)


### PR DESCRIPTION
Scipy's interp1d and interp2d functions were considered "legacy" (i.e., not supported anymore). This PR replaces their use with the recommended alternatives in https://docs.scipy.org/doc/scipy/tutorial/interpolate/interp_transition_guide.html#interp-transition-guide and https://docs.scipy.org/doc/scipy/tutorial/interpolate/1D.html#recommended-replacements-for-interp1d-modes